### PR TITLE
iOS messaging

### DIFF
--- a/ExampleApp/Assets/ButtonController.cs
+++ b/ExampleApp/Assets/ButtonController.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using OptimoveSdk;
 using OptimoveSdk.MiniJSON;
 using System.Collections.Generic;
+using System;
 
 public class ButtonController : MonoBehaviour
 {
@@ -117,53 +118,102 @@ public class ButtonController : MonoBehaviour
     // registration
     void PushRegister()
     {
-
+         Optimove.Shared.PushRegister();
     }
 
     void PushUnregister()
     {
-
+        Optimove.Shared.PushUnregister();
     }
 
     void InAppConsentTrue()
     {
-
+        Optimove.Shared.InAppUpdateConsent(true);
     }
 
     void InAppConsentFalse()
     {
-
+        Optimove.Shared.InAppUpdateConsent(false);
     }
 
     // messaging
     void PresentInboxMessage()
     {
+        int targetId = ReadInboxItemId();
+        if (targetId == 0){
+            return;
+        }
 
+        List<InAppInboxItem> items = Optimove.Shared.InAppGetInboxItems();
+        foreach (var item in items) {
+            if (item.Id == targetId){
+                OptimoveInAppPresentationResult result = Optimove.Shared.InAppPresentInboxMessage(item);
+                break;
+            }
+        }
     }
 
     void DeleteInboxMessage()
     {
+        int targetId = ReadInboxItemId();
+        if (targetId == 0){
+            return;
+        }
 
+        List<InAppInboxItem> items = Optimove.Shared.InAppGetInboxItems();
+        foreach (var item in items) {
+            if (item.Id == targetId){
+                bool result = Optimove.Shared.InAppDeleteMessageFromInbox(item);
+                break;
+            }
+        }
     }
 
     void MarkItemAsRead()
     {
+        int targetId = ReadInboxItemId();
+        if (targetId == 0){
+            return;
+        }
 
+        List<InAppInboxItem> items = Optimove.Shared.InAppGetInboxItems();
+        foreach (var item in items) {
+            if (item.Id == targetId){
+                bool result = Optimove.Shared.InAppMarkAsRead(item);
+                break;
+            }
+        }
     }
 
     void GetInboxItems()
     {
+        List<InAppInboxItem> items = Optimove.Shared.InAppGetInboxItems();
 
+        List<string> result = new List<string>();
+        foreach (var item in items) {
+            result.Add(string.Join(",", new Dictionary<string, string> {
+                {"id", item.Id + ""},
+                {"isRead", item.IsRead + ""},
+                {"sentAt", item.SentAt.ToString()},
+                {"availableFrom", item.AvailableFrom.ToString()},
+            }));
+        }
+
+		m_output.text = string.Join(Environment.NewLine, result);
     }
 
     void MarkAllAsRead()
     {
-
+        bool result = Optimove.Shared.InAppMarkAllInboxItemsRead();
     }
 
     void GetInboxSummary()
     {
-
+        Optimove.Shared.GetInboxSummaryAsync((InAppInboxSummary summary) => {
+            if (summary != null){
+                m_output.text = "InboxSummary. totalCount: " + summary.TotalCount + " unreadCount: "+ summary.UnreadCount;
+            }
+        });
     }
 
 
@@ -175,5 +225,38 @@ public class ButtonController : MonoBehaviour
 
 
 
+    // helpers
+    int ReadInboxItemId()
+    {
+        int targetId = 0;
+        try {
+            targetId = Int32.Parse(m_inboxItemId.text);
+        }
+        catch (FormatException) {
+        }
+        catch (OverflowException) {
+           Console.WriteLine("Invalid inbox item id: {0}", m_inboxItemId.text);
+        }
 
+        if (targetId <= 0){
+            Console.WriteLine("Inbox item id must be a positive integer: {0}", m_inboxItemId.text);
+        }
+
+        return targetId;
+    }
+
+
+
+
+
+
+// setOnInboxUpdatedHandler: (inboxUpdatedHandler: InAppInboxUpdatedHandler) void;
+
+// setPushOpenedHandler(pushOpenedHandler: PushNotificationHandler) void;
+
+// setPushReceivedHandler(pushReceivedHandler: PushNotificationHandler) void;
+
+// setInAppDeepLinkHandler(inAppDeepLinkHandler: InAppDeepLinkHandler) void;
+
+// setDeepLinkHandler(deepLinkHandler: DeepLinkHandler) void;
 }

--- a/ExampleApp/Assets/ButtonController.cs
+++ b/ExampleApp/Assets/ButtonController.cs
@@ -6,28 +6,57 @@ using System.Collections.Generic;
 
 public class ButtonController : MonoBehaviour
 {
-    public InputField m_userIdInput, m_userEmailInput, m_screenName, m_screenCategory, m_eventType, m_eventProps;
-    public Button m_reportScreenVisit, m_reportEvent, m_setUserIdButton, m_setUserEmailButton, m_registerUserButton, m_getVisitorId, m_signOutUser;
+    // events
+    public InputField m_screenName, m_screenCategory, m_eventType, m_eventProps;
+    public Button m_reportScreenVisit, m_reportEvent;
+
+    // association
+    public InputField m_userIdInput, m_userEmailInput;
+    public Button m_setUserIdButton, m_setUserEmailButton, m_registerUserButton, m_getVisitorId, m_signOutUser;
+
+    // registration
+    public Button m_pushRegister, m_pushUnregister, m_inAppConsentTrue, m_inAppConsentFalse;
+
+    // messaging
+    public InputField m_inboxItemId;
+    public Button m_presentInboxMessage, m_deleteInboxMessage, m_markItemAsRead, m_getInboxItems, m_MarkAllAsRead, m_getInboxSummary;
+
+    // output
     public Button m_clearOutput;
     public Text m_output;
 
     void Start()
     {
-        //events
+        // events
         m_reportScreenVisit.onClick.AddListener(ReportScreenVisit);
         m_reportEvent.onClick.AddListener(ReportEvent);
 
-        //user association
+        // user association
         m_setUserIdButton.onClick.AddListener(SetUserId);
         m_setUserEmailButton.onClick.AddListener(SetUserEmail);
         m_registerUserButton.onClick.AddListener(RegisterUser);
         m_getVisitorId.onClick.AddListener(GetVisitorId);
         m_signOutUser.onClick.AddListener(SignOutUser);
 
-        //clear output
+        // registration
+        m_pushRegister.onClick.AddListener(PushRegister);
+        m_pushUnregister.onClick.AddListener(PushUnregister);
+        m_inAppConsentTrue.onClick.AddListener(InAppConsentTrue);
+        m_inAppConsentFalse.onClick.AddListener(InAppConsentFalse);
+
+        // messaging
+        m_presentInboxMessage.onClick.AddListener(PresentInboxMessage);
+        m_deleteInboxMessage.onClick.AddListener(DeleteInboxMessage);
+        m_markItemAsRead.onClick.AddListener(MarkItemAsRead);
+        m_getInboxItems.onClick.AddListener(GetInboxItems);
+        m_MarkAllAsRead.onClick.AddListener(MarkAllAsRead);
+        m_getInboxSummary.onClick.AddListener(GetInboxSummary);
+
+        // clear output
         m_clearOutput.onClick.AddListener(ClearOutput);
     }
 
+    // events
     void ReportScreenVisit()
     {
         string category = m_screenCategory.text;
@@ -53,6 +82,7 @@ public class ButtonController : MonoBehaviour
         m_eventProps.text = "";
     }
 
+    // association
     void SetUserId()
     {
         Optimove.Shared.SetUserId(m_userIdInput.text);
@@ -84,6 +114,60 @@ public class ButtonController : MonoBehaviour
         Optimove.Shared.SignOutUser();
     }
 
+    // registration
+    void PushRegister()
+    {
+
+    }
+
+    void PushUnregister()
+    {
+
+    }
+
+    void InAppConsentTrue()
+    {
+
+    }
+
+    void InAppConsentFalse()
+    {
+
+    }
+
+    // messaging
+    void PresentInboxMessage()
+    {
+
+    }
+
+    void DeleteInboxMessage()
+    {
+
+    }
+
+    void MarkItemAsRead()
+    {
+
+    }
+
+    void GetInboxItems()
+    {
+
+    }
+
+    void MarkAllAsRead()
+    {
+
+    }
+
+    void GetInboxSummary()
+    {
+
+    }
+
+
+    // output
     void ClearOutput()
     {
        m_output.text = "";

--- a/ExampleApp/Assets/ButtonController.cs
+++ b/ExampleApp/Assets/ButtonController.cs
@@ -80,7 +80,7 @@ public class ButtonController : MonoBehaviour
             string id = push.Id.ToString();
             string title = push.Title ?? "";
             string message = push.Message ?? "";
-            string data = push.Data != null ? string.Join(",", push.Data) : "";
+            string data = push.Data != null ? OptimoveSdk.MiniJSON.Json.Serialize(push.Data) : "";
 
             AddLogMessage("PushOpenedHandler: " + "id: " + id + " title: " + title + " message: " + message + " data: " + data);
         };

--- a/ExampleApp/Assets/ButtonController.cs
+++ b/ExampleApp/Assets/ButtonController.cs
@@ -56,6 +56,41 @@ public class ButtonController : MonoBehaviour
 
         // clear output
         m_clearOutput.onClick.AddListener(ClearOutput);
+
+        SetUpHandlers();
+    }
+
+    void SetUpHandlers()
+    {
+        Optimove.Shared.OnInAppDeepLinkPressed += (Dictionary<string, object> data) =>
+        {
+            AddLogMessage("InAppDeepLinkPressedHandler: " + OptimoveSdk.MiniJSON.Json.Serialize(data));
+        };
+
+        Optimove.Shared.OnInAppInboxUpdated += () =>
+        {
+            AddLogMessage("InAppInboxUpdatedHandler");
+        };
+
+        Optimove.Shared.OnPushOpened += (PushMessage push) =>
+        {
+            string id = push.Id.ToString();
+            string title = push.Title ?? "";
+            string message = push.Message ?? "";
+            string data = push.Data != null ? string.Join(",", push.Data) : "";
+
+            AddLogMessage("PushOpenedHandler: " + "id: " + id + " title: " + title + " message: " + message + " data: " + data);
+        };
+
+        Optimove.Shared.OnPushReceived += (PushMessage push) =>
+        {
+             string id = push.Id.ToString();
+            string title = push.Title ?? "";
+            string message = push.Message ?? "";
+            string data = push.Data != null ? OptimoveSdk.MiniJSON.Json.Serialize(push.Data) : "";
+
+            AddLogMessage("PushReceivedHandler: " + "id: " + id + " title: " + title + " message: " + message + " data: " + data);
+        };
     }
 
     // events
@@ -261,17 +296,4 @@ public class ButtonController : MonoBehaviour
        ButtonController.logMessages.Clear();
        m_output.text = "";
     }
-
-
-
-
-// setOnInboxUpdatedHandler: (inboxUpdatedHandler: InAppInboxUpdatedHandler) void;
-
-// setPushOpenedHandler(pushOpenedHandler: PushNotificationHandler) void;
-
-// setPushReceivedHandler(pushReceivedHandler: PushNotificationHandler) void;
-
-// setInAppDeepLinkHandler(inAppDeepLinkHandler: InAppDeepLinkHandler) void;
-
-// setDeepLinkHandler(deepLinkHandler: DeepLinkHandler) void;
 }

--- a/ExampleApp/Assets/ButtonController.cs
+++ b/ExampleApp/Assets/ButtonController.cs
@@ -26,6 +26,7 @@ public class ButtonController : MonoBehaviour
     public Button m_clearOutput;
     public Text m_output;
 
+    private static List<string> logMessages = new List<string>();
     void Start()
     {
         // events
@@ -107,7 +108,7 @@ public class ButtonController : MonoBehaviour
 
     void GetVisitorId()
     {
-        m_output.text = Optimove.Shared.GetVisitorId();
+        AddLogMessage(Optimove.Shared.GetVisitorId());
     }
 
     void SignOutUser()
@@ -118,21 +119,25 @@ public class ButtonController : MonoBehaviour
     // registration
     void PushRegister()
     {
-         Optimove.Shared.PushRegister();
+        AddLogMessage("Registering for push");
+        Optimove.Shared.PushRegister();
     }
 
     void PushUnregister()
     {
+        AddLogMessage("Unregistering for push");
         Optimove.Shared.PushUnregister();
     }
 
     void InAppConsentTrue()
     {
+        AddLogMessage("Updating in-app consent: true");
         Optimove.Shared.InAppUpdateConsent(true);
     }
 
     void InAppConsentFalse()
     {
+        AddLogMessage("Updating in-app consent: false");
         Optimove.Shared.InAppUpdateConsent(false);
     }
 
@@ -148,6 +153,7 @@ public class ButtonController : MonoBehaviour
         foreach (var item in items) {
             if (item.Id == targetId){
                 OptimoveInAppPresentationResult result = Optimove.Shared.InAppPresentInboxMessage(item);
+                AddLogMessage("Present message result: " + result.ToString());
                 break;
             }
         }
@@ -164,6 +170,7 @@ public class ButtonController : MonoBehaviour
         foreach (var item in items) {
             if (item.Id == targetId){
                 bool result = Optimove.Shared.InAppDeleteMessageFromInbox(item);
+                AddLogMessage("Delete message result: " + result);
                 break;
             }
         }
@@ -180,6 +187,7 @@ public class ButtonController : MonoBehaviour
         foreach (var item in items) {
             if (item.Id == targetId){
                 bool result = Optimove.Shared.InAppMarkAsRead(item);
+                AddLogMessage("Mark item read result: " + result);
                 break;
             }
         }
@@ -199,31 +207,25 @@ public class ButtonController : MonoBehaviour
             }));
         }
 
-		m_output.text = string.Join(Environment.NewLine, result);
+        string toLog = result.Count == 0 ? "[]" : string.Join(Environment.NewLine, result);
+        AddLogMessage(toLog);
     }
 
     void MarkAllAsRead()
     {
         bool result = Optimove.Shared.InAppMarkAllInboxItemsRead();
+
+        AddLogMessage("Mark all items read result: " + result);
     }
 
     void GetInboxSummary()
     {
         Optimove.Shared.GetInboxSummaryAsync((InAppInboxSummary summary) => {
             if (summary != null){
-                m_output.text = "InboxSummary. totalCount: " + summary.TotalCount + " unreadCount: "+ summary.UnreadCount;
+                AddLogMessage("InboxSummary. totalCount: " + summary.TotalCount + " unreadCount: "+ summary.UnreadCount);
             }
         });
     }
-
-
-    // output
-    void ClearOutput()
-    {
-       m_output.text = "";
-    }
-
-
 
     // helpers
     int ReadInboxItemId()
@@ -245,7 +247,20 @@ public class ButtonController : MonoBehaviour
         return targetId;
     }
 
+    void AddLogMessage(string message)
+    {
+        string prefix = DateTime.Now.ToString("[MM/dd/yyyy h:mm:ss]: ");
 
+        ButtonController.logMessages.Add(prefix + message);
+
+        m_output.text = string.Join(Environment.NewLine, ButtonController.logMessages);
+    }
+
+    void ClearOutput()
+    {
+       ButtonController.logMessages.Clear();
+       m_output.text = "";
+    }
 
 
 

--- a/ExampleApp/Assets/ButtonController.cs
+++ b/ExampleApp/Assets/ButtonController.cs
@@ -62,9 +62,12 @@ public class ButtonController : MonoBehaviour
 
     void SetUpHandlers()
     {
-        Optimove.Shared.OnInAppDeepLinkPressed += (Dictionary<string, object> data) =>
+        Optimove.Shared.OnInAppDeepLinkPressed += (InAppButtonPress press) =>
         {
-            AddLogMessage("InAppDeepLinkPressedHandler: " + OptimoveSdk.MiniJSON.Json.Serialize(data));
+            string deepLinkData = OptimoveSdk.MiniJSON.Json.Serialize(press.DeepLinkData);
+            string messageData = OptimoveSdk.MiniJSON.Json.Serialize(press.MessageData);
+
+            AddLogMessage( "InAppDeepLinkPressedHandler: Message id: " + press.MessageId + " deepLinkData: " + deepLinkData + " messageData: " + messageData);
         };
 
         Optimove.Shared.OnInAppInboxUpdated += () =>

--- a/ExampleApp/Assets/OptimoveSdk/Editor/SetUpXcodeProject.cs
+++ b/ExampleApp/Assets/OptimoveSdk/Editor/SetUpXcodeProject.cs
@@ -6,43 +6,83 @@ using System.IO;
 using UnityEditor;
 using System.Collections.Generic;
 
-/*
- * This class sets up the Xcode native project for iOS with the necessary capabilities & dependencies for analytics, crash reporting, and push notifications.
- *
- */
 public class SetUpXcodeProject
 {
-
-    //private const string kCoreDataFramework = "CoreData.framework";
-    //private const string kUserNotificationsFramework = "UserNotifications.framework";
+    private static readonly string _appGroupName = $"group.{PlayerSettings.applicationIdentifier}.optimove";
 
     [PostProcessBuild]
     public static void ChangeXcodePlist(BuildTarget buildTarget, string pathToBuiltProject)
     {
-        if (buildTarget == BuildTarget.iOS)
+        if (buildTarget != BuildTarget.iOS)
         {
-            var projectPath = PBXProject.GetPBXProjectPath(pathToBuiltProject);
-            var project = new PBXProject();
-
-            project.ReadFromFile(projectPath);
-
-            #if UNITY_2019_3_OR_NEWER
-                var unityTarget = project.GetUnityFrameworkTargetGuid();
-
-                SetModuleMap(project, unityTarget, pathToBuiltProject);
-            #else
-                // TODO: not supported?
-                var unityTarget = project.TargetGuidByName(PBXProject.GetUnityTargetName());
-            #endif
-
-
-
-            // SetBuildProperties(project, unityTarget);
-            // LinkCoreData(project, unityTarget, pathToBuiltProject);
-            // SetupPushCapabilities(project, unityTarget, pathToBuiltProject);
-
-            project.WriteToFile(projectPath);
+            return;
         }
+
+        #if UNITY_2019_3_OR_NEWER
+            DoProjectSetup(buildTarget, pathToBuiltProject);
+        #endif
+    }
+
+    private static void DoProjectSetup(BuildTarget buildTarget, string pathToBuiltProject)
+    {
+        var projectPath = PBXProject.GetPBXProjectPath(pathToBuiltProject);
+        var project = new PBXProject();
+
+        project.ReadFromFile(projectPath);
+
+        var unityTarget = project.GetUnityFrameworkTargetGuid();
+
+        // Push Notifications, Background Modes, App Groups for the main target
+        SetupMainTargetCapabilities(project, projectPath, pathToBuiltProject);
+
+        // enables calling objc functions from swift
+        SetModuleMap(project, unityTarget, pathToBuiltProject);
+
+        project.WriteToFile(projectPath);
+    }
+
+    private static void SetupMainTargetCapabilities(PBXProject project, string projectPath, string pathToBuiltProject) {
+        //2019.3+ only
+        var mainTargetGuid = project.GetUnityMainTargetGuid();
+        var mainTargetName = "Unity-iPhone";
+
+        var entitlementsPath = GetEntitlementsPath(project, mainTargetGuid, mainTargetName, pathToBuiltProject);
+        var projCapability = new ProjectCapabilityManager(projectPath, entitlementsPath, mainTargetName);
+
+        projCapability.AddBackgroundModes(BackgroundModesOptions.RemoteNotifications | BackgroundModesOptions.BackgroundFetch);
+
+        projCapability.AddPushNotifications(false);
+        projCapability.AddAppGroups(new[] { _appGroupName });
+
+        projCapability.WriteToFile();
+    }
+
+    // Get existing entitlements file if exists or creates a new file, adds it to the project, and returns the path
+    private static string GetEntitlementsPath(PBXProject project, string targetGuid, string targetName, string pathToBuiltProject) {
+        var relativePath = project.GetBuildPropertyForAnyConfig(targetGuid, "CODE_SIGN_ENTITLEMENTS");
+
+        if (relativePath != null) {
+            var fullPath = Path.Combine(pathToBuiltProject, relativePath);
+
+            if (File.Exists(fullPath))
+                return fullPath;
+        }
+
+        var entitlementsPath = Path.Combine(pathToBuiltProject, targetName, $"{targetName}.entitlements");
+
+        // make new file
+        var entitlementsPlist = new PlistDocument();
+        entitlementsPlist.WriteToFile(entitlementsPath);
+
+        // Copy the entitlement file to the xcode project
+        var entitlementFileName = Path.GetFileName(entitlementsPath);
+        var relativeDestination = targetName + "/" + entitlementFileName;
+
+        // Add the pbx configs to include the entitlements files on the project
+        project.AddFile(relativeDestination, entitlementFileName);
+        project.SetBuildProperty(targetGuid, "CODE_SIGN_ENTITLEMENTS", relativeDestination);
+
+        return relativeDestination;
     }
 
     private static void SetModuleMap(PBXProject project, string unityTarget, string buildPath)
@@ -62,43 +102,4 @@ public class SetUpXcodeProject
         string pluginObjcInterfaceGuid = project.FindFileGuidByProjectPath("Libraries/Plugins/iOS/Swift-objc-bridging-header.h");
         project.AddPublicHeaderToBuild(unityTarget, pluginObjcInterfaceGuid);
     }
-
-
-    // private static void SetupPushCapabilities(PBXProject project, string unityTarget, string pathToBuiltProject)
-    // {
-    //     if (!project.ContainsFramework(unityTarget, kUserNotificationsFramework))
-    //     {
-    //         project.AddFrameworkToProject(unityTarget, kUserNotificationsFramework, true);
-    //     }
-
-    //     project.AddCapability(unityTarget, PBXCapabilityType.PushNotifications);
-
-    //     string plistPath = pathToBuiltProject + "/Info.plist";
-    //     PlistDocument plist = new PlistDocument();
-    //     plist.ReadFromFile(plistPath);
-
-    //     PlistElementDict rootDict = plist.root;
-
-    //     // Add our background mode
-    //     var buildKey = "UIBackgroundModes";
-    //     var backgroundModes = rootDict.CreateArray(buildKey);
-    //     backgroundModes.AddString("fetch");
-    //     backgroundModes.AddString("remote-notification");
-
-    //     plist.WriteToFile(plistPath);
-    // }
-
-	// private static void LinkCoreData(PBXProject project, string unityTarget, string pathToBuiltProject)
-    // {
-    //     if (!project.ContainsFramework(unityTarget, kCoreDataFramework))
-    //     {
-    //         project.AddFrameworkToProject(unityTarget, kCoreDataFramework, false);
-    //     }
-    // }
-
-    // private static void SetBuildProperties(PBXProject project, string unityTarget)
-    // {
-    //     project.AddBuildProperty(unityTarget, "OTHER_LDFLAGS", "-ObjC");
-    //     project.AddBuildPropertyForConfig(project.BuildConfigByName(unityTarget, "Debug"), "GCC_PREPROCESSOR_DEFINITIONS[arch=*]", "DEBUG=1");
-    // }
 }

--- a/ExampleApp/Assets/OptimoveSdk/Models.cs
+++ b/ExampleApp/Assets/OptimoveSdk/Models.cs
@@ -14,45 +14,36 @@ namespace OptimoveSdk
         }
     }
 
-    // public class PushMessage
-    // {
-    //     public string Id { get; private set; }
-    //     public string Title { get; private set; }
-    //     public string Message { get; private set; }
-    //     public Dictionary<string, object> Data { get; private set; }
-    //     public string Url { get; private set; }
-    //     public bool IsBackground { get; private set; }
-    //     public bool DidOpenFromPush { get; private set; }
-    //     public string ActionId { get; private set; }
+    public class PushMessage
+    {
+        public long Id { get; private set; }
+        public string Title { get; private set; }
+        public string Message { get; private set; }
+        public Dictionary<string, object> Data { get; private set; }
+        public string Url { get; private set; }
+        public string ActionId { get; private set; }
 
-    //     public static PushMessage CreateFromJson(string message)
-    //     {
-    //         var data = MiniJSON.Json.Deserialize(message) as Dictionary<string, object>;
+        public static PushMessage CreateFromJson(string message)
+        {
+            var data = MiniJSON.Json.Deserialize(message) as Dictionary<string, object>;
 
-    //         if (data == null)
-    //         {
-    //             return null;
-    //         }
+            if (data == null)
+            {
+                return null;
+            }
 
-    //         var push = new PushMessage();
+            var push = new PushMessage();
 
-    //         push.Id = data.GetValueOrDefault("id") as string;
-    //         push.Title = data.GetValueOrDefault("title") as string;
-    //         push.Message = data.GetValueOrDefault("message") as string;
-    //         push.Url = data.GetValueOrDefault("url") as string;
-    //         push.IsBackground = (bool)data.GetValueOrDefault("isBackground");
-    //         push.DidOpenFromPush = (bool)data.GetValueOrDefault("didOpenFromPush");
-    //         push.Data = data.GetValueOrDefault("data") as Dictionary<string, object>;
+            push.Id = (long)data["id"];
+            push.Title = data.GetValueOrDefault("title") as string;
+            push.Message = data.GetValueOrDefault("message") as string;
+            push.Url = data.GetValueOrDefault("url") as string;
+            push.Data = data.GetValueOrDefault("data") as Dictionary<string, object>;
+            push.ActionId =  data.GetValueOrDefault("actionId") as string;
 
-    //         string actionId = data.GetValueOrDefault("actionId") as string;
-    //         if (actionId != null){
-    //             push.ActionId = actionId;
-    //         }
-
-    //         return push;
-    //     }
-    // }
-
+            return push;
+        }
+    }
 
     public class InAppInboxSummary
     {
@@ -74,7 +65,6 @@ namespace OptimoveSdk
         expired,
         failed
     }
-
 
     public class InAppInboxItem
     {

--- a/ExampleApp/Assets/OptimoveSdk/Models.cs
+++ b/ExampleApp/Assets/OptimoveSdk/Models.cs
@@ -54,74 +54,95 @@ namespace OptimoveSdk
     // }
 
 
-    // public class InAppInboxSummary
-    // {
-    //     public uint TotalCount { get; private set; }
-    //     public uint UnreadCount { get; private set; }
+    public class InAppInboxSummary
+    {
+        public uint TotalCount { get; private set; }
+        public uint UnreadCount { get; private set; }
 
-    //     internal static InAppInboxSummary CreateFromDictionary(Dictionary<string, object> dict)
-    //     {
-    //         var summary = new InAppInboxSummary();
-    //         summary.TotalCount = Convert.ToUInt32((long) dict["totalCount"]);
-    //         summary.UnreadCount = Convert.ToUInt32((long) dict["unreadCount"]);
-    //         return summary;
-    //     }
-    // }
+        internal static InAppInboxSummary CreateFromDictionary(Dictionary<string, object> dict)
+        {
+            var summary = new InAppInboxSummary();
+            summary.TotalCount = Convert.ToUInt32((long) dict["totalCount"]);
+            summary.UnreadCount = Convert.ToUInt32((long) dict["unreadCount"]);
+            return summary;
+        }
+    }
 
-    // public class InAppInboxItem
-    // {
-    //     public long Id { get; private set; }
-    //     public string Title { get; private set; }
-    //     public string Subtitle { get; private set; }
-    //     public string AvailableFrom { get; private set; }
-    //     public string AvailableTo { get; private set; }
-    //     public string DismissedAt { get; private set; }
-    //     public bool IsRead { get; private set; }
-    //     public string SentAt { get; private set; }
-    //     public Dictionary<string, object> Data { get; private set; }
-    //     public string ImageUrl { get; private set; }
+    public enum OptimoveInAppPresentationResult
+    {
+        presented,
+        expired,
+        failed
+    }
 
-    //     public static List<InAppInboxItem> ListFromJson(string json)
-    //     {
-    //         var parsed = MiniJSON.Json.Deserialize(json) as List<object>;
 
-    //         var items = new List<InAppInboxItem>();
-    //         if (parsed == null)
-    //         {
-    //             return items;
-    //         }
+    public class InAppInboxItem
+    {
+        public long Id { get; private set; }
+        public string Title { get; private set; }
+        public string Subtitle { get; private set; }
+        public DateTime? AvailableFrom { get; private set; }
+        public DateTime? AvailableTo { get; private set; }
+        public DateTime? DismissedAt { get; private set; }
+        public bool IsRead { get; private set; }
+        public DateTime SentAt { get; private set; }
+        public Dictionary<string, object> Data { get; private set; }
+        public string ImageUrl { get; private set; }
 
-    //         foreach (var obj in parsed)
-    //         {
-    //             items.Add(CreateFromObj(obj));
-    //         }
+        public static List<InAppInboxItem> ListFromJson(string json)
+        {
+            var parsed = MiniJSON.Json.Deserialize(json) as List<object>;
 
-    //         return items;
-    //     }
+            var items = new List<InAppInboxItem>();
+            if (parsed == null)
+            {
+                return items;
+            }
 
-    //     private static InAppInboxItem CreateFromObj(object parsed)
-    //     {
-    //         var obj = parsed as Dictionary<string, object>;
+            foreach (var obj in parsed)
+            {
+                items.Add(CreateFromObj(obj));
+            }
 
-    //         if (parsed == null || obj == null)
-    //         {
-    //             return null;
-    //         }
+            return items;
+        }
 
-    //         var item = new InAppInboxItem();
+        private static InAppInboxItem CreateFromObj(object parsed)
+        {
+            var obj = parsed as Dictionary<string, object>;
 
-    //         item.Id = (long)obj["id"];
-    //         item.Title = obj["title"] as string;
-    //         item.Subtitle = obj["subtitle"] as string;
-    //         item.AvailableFrom = obj["availableFrom"] as string;
-    //         item.AvailableTo = obj["availableTo"] as string;
-    //         item.DismissedAt = obj["dismissedAt"] as string;
-    //         item.IsRead = (bool)obj.GetValueOrDefault("isRead");
-    //         item.SentAt = obj.GetValueOrDefault("sentAt") as string;
-    //         item.Data = obj.GetValueOrDefault("data") as Dictionary<string, object>;
-    //         item.ImageUrl = obj.GetValueOrDefault("imageUrl") as string;
+            if (parsed == null || obj == null)
+            {
+                return null;
+            }
 
-    //         return item;
-    //     }
-    // }
+            var item = new InAppInboxItem();
+
+            item.Id = (long)obj["id"];
+            item.Title = obj["title"] as string;
+            item.Subtitle = obj["subtitle"] as string;
+            item.AvailableFrom = InAppInboxItem.parseOptionalDate(obj.GetValueOrDefault("availableFrom") as string);
+            item.AvailableTo = InAppInboxItem.parseOptionalDate(obj.GetValueOrDefault("availableTo") as string);
+            item.DismissedAt = InAppInboxItem.parseOptionalDate(obj.GetValueOrDefault("dismissedAt") as string);
+            item.IsRead = (bool)obj.GetValueOrDefault("isRead");
+            item.SentAt = parseDate(obj["sentAt"] as string);
+            item.Data = obj.GetValueOrDefault("data") as Dictionary<string, object>;
+            item.ImageUrl = obj.GetValueOrDefault("imageUrl") as string;
+
+            return item;
+        }
+
+		private static DateTime? parseOptionalDate(string date)
+		{
+			if (date == null){
+				return null;
+			}
+
+			return parseDate(date);
+		}
+
+		private static DateTime parseDate(string date){
+			return DateTime.Parse(date, null, System.Globalization.DateTimeStyles.RoundtripKind);
+		}
+    }
 }

--- a/ExampleApp/Assets/OptimoveSdk/Models.cs
+++ b/ExampleApp/Assets/OptimoveSdk/Models.cs
@@ -59,6 +59,24 @@ namespace OptimoveSdk
         }
     }
 
+    public class InAppButtonPress
+    {
+        public long MessageId { get; private set; }
+        public Dictionary<string, object> DeepLinkData { get; private set; }
+        public Dictionary<string, object> MessageData { get; private set; }
+
+        internal static InAppButtonPress CreateFromJson(string json)
+        {
+            var data = MiniJSON.Json.Deserialize(json) as Dictionary<string, object>;
+
+            var press = new InAppButtonPress();
+            press.MessageId = (long) data["messageId"];
+            press.DeepLinkData = data["deepLinkData"] as Dictionary<string, object>;
+            press.MessageData = data.GetValueOrDefault("messageData") as Dictionary<string, object>;
+            return press;
+        }
+    }
+
     public enum OptimoveInAppPresentationResult
     {
         presented,

--- a/ExampleApp/Assets/OptimoveSdk/Optimove.cs
+++ b/ExampleApp/Assets/OptimoveSdk/Optimove.cs
@@ -20,7 +20,7 @@ namespace OptimoveSdk
         public delegate void PushOpenedDelegate(PushMessage message);
         public event PushOpenedDelegate OnPushOpened;
 
-        public delegate void InAppDeepLinkDelegate(Dictionary<string, object> message);
+        public delegate void InAppDeepLinkDelegate(InAppButtonPress press);
         public event InAppDeepLinkDelegate OnInAppDeepLinkPressed;
 
         public delegate void InAppInboxUpdatedDelegate();
@@ -314,16 +314,16 @@ namespace OptimoveSdk
                 #endif
         }
 
-        public void InAppDeepLinkPressed(string dataJson)//TODO: dictionary to model? not in Flutter, but in cordova
+        public void InAppDeepLinkPressed(string dataJson)
         {
-            if (OnInAppDeepLinkPressed == null)
-            {
-                return;
-            }
+                if (OnInAppDeepLinkPressed == null)
+                {
+                        return;
+                }
 
-            var data = MiniJSON.Json.Deserialize(dataJson) as Dictionary<string, object>;
+                var press = InAppButtonPress.CreateFromJson(dataJson);
 
-            OnInAppDeepLinkPressed(data);
+                OnInAppDeepLinkPressed(press);
         }
 
         public void InAppInboxUpdated()

--- a/ExampleApp/Assets/OptimoveSdk/Optimove.cs
+++ b/ExampleApp/Assets/OptimoveSdk/Optimove.cs
@@ -41,14 +41,12 @@ namespace OptimoveSdk
         public static void Initialize()
         {
 #if UNITY_ANDROID
-            AndroidProxy = new AndroidJavaClass("com.optimove.unity.plugin.UnityProxy");
+        AndroidProxy = new AndroidJavaClass("com.optimove.unity.plugin.UnityProxy");
 #endif
 
             var optimoveGameObject = new GameObject(GameObjectName);
             optimoveGameObject.AddComponent<Optimove>();
             DontDestroyOnLoad(optimoveGameObject);
-
-
         }
 
         #endregion
@@ -195,21 +193,26 @@ namespace OptimoveSdk
 
 //         #endregion
 
-//         #region Push
+        #region Push
 
-//         public void PushRegister()
-//         {
-// #if UNITY_IOS
-//             Optimove.KSPushRequestDeviceToken();
-// #elif UNITY_ANDROID
-//             AndroidProxy.CallStatic("pushRegUnreg", new object[] { true });
-// #endif
-//         }
+        public void PushRegister()
+        {
+                #if UNITY_IOS
+                        OptimoveUpdatePushRegistration(1);
+                #elif UNITY_ANDROID
+                        //AndroidProxy.CallStatic("pushRegUnreg", new object[] { true });
+                #endif
+        }
 
-//         public void PushUnregister()
-//         {
-//             //TODO:
-//         }
+        public void PushUnregister()
+        {
+                #if UNITY_IOS
+                        OptimoveUpdatePushRegistration(0);
+                #elif UNITY_ANDROID
+                        //TODO
+                #endif
+        }
+
 
 //         public void PushReceived(string message)
 //         {
@@ -225,9 +228,22 @@ namespace OptimoveSdk
 
     //TODO: PushOpened?
 
-//         #endregion
+        #endregion
 
-//         #region InApp
+        #region InApp
+
+        public void InAppUpdateConsent(bool consented)
+        {
+                #if UNITY_IOS
+                        if (consented) {
+                                OptimoveInAppUpdateConsentForUser(1);
+                        } else {
+                                OptimoveInAppUpdateConsentForUser(0);
+                        }
+                #elif UNITY_ANDROID
+                        //TODO
+                #endif
+        }
 
 //         public void InAppDeepLinkPressed(string dataJson)
 //         {
@@ -251,128 +267,118 @@ namespace OptimoveSdk
 //             OnInAppInboxUpdated();
 //         }
 
-//         public void InAppUpdateConsent(bool consented)
-//         {
-// #if UNITY_IOS
-//             if (consented) {
-//                 KSInAppUpdateConsentForUser(1);
-//             } else {
-//                 KSInAppUpdateConsentForUser(0);
-//             }
-// #elif UNITY_ANDROID
-//             AndroidProxy.CallStatic("inAppUpdateConsentForUser", new object[] { consented });
-// #endif
-//         }
-
-//         public List<InAppInboxItem> InAppGetInboxItems()
-//         {
-//             string json = "[]";
-// #if UNITY_IOS
-//             json = KSInAppGetInboxItems();
-// #elif UNITY_ANDROID
-//             json = AndroidProxy.CallStatic<string>("inAppGetInboxItems", new object[] { });
-// #endif
-
-//             return InAppInboxItem.ListFromJson(json);
-//         }
-
-//         public bool InAppPresentInboxMessage(InAppInboxItem item)
-//         {
-// #if UNITY_IOS
-//             return KSInAppPresentInboxMessage(item.Id);
-// #elif UNITY_ANDROID
-//             return AndroidProxy.CallStatic<bool>("inAppPresentInboxMessage", new object[] { item.Id });
-// #else
-// 			return false;
-// #endif
-//         }
-
-//         public bool InAppDeleteMessageFromInbox(InAppInboxItem item)
-//         {
-// #if UNITY_IOS
-//             return KSInAppDeleteMessageFromInbox(item.Id);
-// #elif UNITY_ANDROID
-//             return AndroidProxy.CallStatic<bool>("inAppDeleteMessageFromInbox", new object[] { item.Id });
-// #else
-// 			return false;
-// #endif
-//         }
-
-//         public bool InAppMarkAsRead(InAppInboxItem item)
-//         {
-// #if UNITY_IOS
-//             return KSInAppMarkInboxItemRead(item.Id);
-// #elif UNITY_ANDROID
-//             return AndroidProxy.CallStatic<bool>("inAppMarkInboxItemRead", new object[] { item.Id });
-// #else
-// 			return false;
-// #endif
-//         }
 
 
-//         public bool InAppMarkAllInboxItemsRead()
-//         {
-// #if UNITY_IOS
-//             return KSInAppMarkAllInboxItemsRead();
-// #elif UNITY_ANDROID
-//             return AndroidProxy.CallStatic<bool>("inAppMarkAllInboxItemsRead", new object[] { });
-// #else
-// 			return false;
-// #endif
-//         }
+        public List<InAppInboxItem> InAppGetInboxItems()
+        {
+                string json = "[]";
+                #if UNITY_IOS
+                        json = OptimoveInAppGetInboxItems();
+                #elif UNITY_ANDROID
+                        //json = AndroidProxy.CallStatic<string>("inAppGetInboxItems", new object[] { });
+                #endif
+
+                return InAppInboxItem.ListFromJson(json);
+        }
+
+        public OptimoveInAppPresentationResult InAppPresentInboxMessage(InAppInboxItem item)
+        {
+                #if UNITY_IOS
+                        string result = OptimoveInAppPresentInboxMessage(item.Id);
+                #elif UNITY_ANDROID
+                        //return AndroidProxy.CallStatic<bool>("inAppPresentInboxMessage", new object[] { item.Id });
+                #else
+                        return OptimoveInAppPresentationResult.Failed;
+                #endif
+
+                return (OptimoveInAppPresentationResult) Enum.Parse(typeof(OptimoveInAppPresentationResult), result, true);
+        }
+
+        public bool InAppDeleteMessageFromInbox(InAppInboxItem item)
+        {
+                #if UNITY_IOS
+                        return OptimoveInAppDeleteMessageFromInbox(item.Id);
+                #elif UNITY_ANDROID
+                        //return AndroidProxy.CallStatic<bool>("inAppDeleteMessageFromInbox", new object[] { item.Id });
+                #else
+                        return false;
+                #endif
+        }
+
+        public bool InAppMarkAsRead(InAppInboxItem item)
+        {
+                #if UNITY_IOS
+                        return OptimoveInAppMarkAsRead(item.Id);
+                #elif UNITY_ANDROID
+                        //return AndroidProxy.CallStatic<bool>("inAppMarkInboxItemRead", new object[] { item.Id });
+                #else
+                        return false;
+                #endif
+        }
 
 
-//         //**************************************** SUMMARY ************************************************
-//         private static Dictionary<string, Action<InAppInboxSummary>> inboxSummaryHandlers = new Dictionary<string, Action<InAppInboxSummary>>();
-
-//         private string CacheInboxSummaryHandler(Action<InAppInboxSummary> inboxSummaryHandler)
-//         {
-//             string guid = Guid.NewGuid().ToString();
-//             while(inboxSummaryHandlers.ContainsKey(guid)){
-//                 guid = Guid.NewGuid().ToString();
-//             }
-
-//             inboxSummaryHandlers.Add(guid, inboxSummaryHandler);
-
-//             return guid;
-//         }
-
-//         private void InvokeInboxSummaryHandler(string resultJson)
-//         {
-//             var parsed = MiniJSON.Json.Deserialize(resultJson) as Dictionary<string, object>;
-//             if (parsed == null){
-//                 return;
-//             }
-
-//             string guid = parsed["guid"] as string;
-//             if (!inboxSummaryHandlers.ContainsKey(guid)){
-//                 return;
-//             }
-
-//             bool success = (bool)parsed.GetValueOrDefault("success");
-//             InAppInboxSummary summary = null;
-//             if (success){
-//                 summary = InAppInboxSummary.CreateFromDictionary(parsed);
-//             }
-
-//             inboxSummaryHandlers[guid](summary);
-//             inboxSummaryHandlers.Remove(guid);
-//         }
-
-//         public void GetInboxSummaryAsync(Action<InAppInboxSummary> inboxSummaryHandler) {
-//             string guid = this.CacheInboxSummaryHandler(inboxSummaryHandler);
-// #if UNITY_IOS
-//             KSInAppGetInboxSummary(guid);
-// #elif UNITY_ANDROID
-//             AndroidProxy.CallStatic("inAppGetInboxSummary", new object[] { guid });
-// #endif
-//         }
+        public bool InAppMarkAllInboxItemsRead()
+        {
+                #if UNITY_IOS
+                        return OptimoveMarkAllInboxItemsAsRead();
+                #elif UNITY_ANDROID
+                        //return AndroidProxy.CallStatic<bool>("inAppMarkAllInboxItemsRead", new object[] { });
+                #else
+                        return false;
+                #endif
+        }
 
 
-//          //************************************************************************************************
+        //**************************************** SUMMARY ************************************************
+        private static Dictionary<string, Action<InAppInboxSummary>> inboxSummaryHandlers = new Dictionary<string, Action<InAppInboxSummary>>();
+
+        public void GetInboxSummaryAsync(Action<InAppInboxSummary> inboxSummaryHandler) {
+                string guid = this.CacheInboxSummaryHandler(inboxSummaryHandler);
+                #if UNITY_IOS
+                        OptimoveInAppGetInboxSummary(guid);
+                #elif UNITY_ANDROID
+                        //AndroidProxy.CallStatic("inAppGetInboxSummary", new object[] { guid });
+                #endif
+        }
+
+        private string CacheInboxSummaryHandler(Action<InAppInboxSummary> inboxSummaryHandler)
+        {
+            string guid = Guid.NewGuid().ToString();
+            while(inboxSummaryHandlers.ContainsKey(guid)){
+                guid = Guid.NewGuid().ToString();
+            }
+
+            inboxSummaryHandlers.Add(guid, inboxSummaryHandler);
+
+            return guid;
+        }
+
+        private void InvokeInboxSummaryHandler(string resultJson)
+        {
+            var parsed = MiniJSON.Json.Deserialize(resultJson) as Dictionary<string, object>;
+            if (parsed == null){
+                return;
+            }
+
+            string guid = parsed["guid"] as string;
+            if (!inboxSummaryHandlers.ContainsKey(guid)){
+                return;
+            }
+
+            bool success = (bool)parsed.GetValueOrDefault("success");
+            InAppInboxSummary summary = null;
+            if (success){
+                summary = InAppInboxSummary.CreateFromDictionary(parsed);
+            }
+
+            inboxSummaryHandlers[guid](summary);
+            inboxSummaryHandlers.Remove(guid);
+        }
+
+        //************************************************************************************************
 
 
-//         #endregion
+        #endregion
 
         #region Native
 
@@ -400,34 +406,29 @@ namespace OptimoveSdk
         [DllImport(nativeLib)]
         private static extern void OptimoveSignOutUser();
 
+        [DllImport(nativeLib)]
+        private static extern void OptimoveUpdatePushRegistration(int state);
 
+        [DllImport(nativeLib)]
+        private static extern void OptimoveInAppUpdateConsentForUser(int consented);
 
+        [DllImport(nativeLib)]
+        private static extern string OptimoveInAppGetInboxItems();
 
+        [DllImport(nativeLib)]
+        private static extern string OptimoveInAppPresentInboxMessage(long messageId);
 
+        [DllImport(nativeLib)]
+        private static extern bool OptimoveInAppDeleteMessageFromInbox(long messageId);
 
-        // [DllImport(nativeLib)]
-        // private static extern void KSPushRequestDeviceToken();
+        [DllImport(nativeLib)]
+        private static extern bool OptimoveInAppMarkAsRead(long messageId);
 
-        // [DllImport(nativeLib)]
-        // private static extern void KSInAppUpdateConsentForUser(int consented);
+        [DllImport(nativeLib)]
+        private static extern bool OptimoveMarkAllInboxItemsAsRead();
 
-        // [DllImport(nativeLib)]
-        // private static extern string KSInAppGetInboxItems();
-
-        // [DllImport(nativeLib)]
-        // private static extern bool KSInAppPresentInboxMessage(long messageId);
-
-        // [DllImport(nativeLib)]
-        // private static extern bool KSInAppDeleteMessageFromInbox(long messageId);
-
-        // [DllImport(nativeLib)]
-        // private static extern bool KSInAppMarkInboxItemRead(long messageId);
-
-        // [DllImport(nativeLib)]
-        // private static extern bool KSInAppMarkAllInboxItemsRead();
-
-        // [DllImport(nativeLib)]
-        // private static extern void KSInAppGetInboxSummary(string guid);
+        [DllImport(nativeLib)]
+        private static extern void OptimoveInAppGetInboxSummary(string guid);
 
 #endif
 

--- a/ExampleApp/Assets/OptimoveSdk/Optimove.cs
+++ b/ExampleApp/Assets/OptimoveSdk/Optimove.cs
@@ -14,17 +14,17 @@ namespace OptimoveSdk
 
         public const string Version = "1.0.0";
 
-        // public delegate void PushReceivedDelegate(PushMessage message);
+        public delegate void PushReceivedDelegate(PushMessage message);
+        public event PushReceivedDelegate OnPushReceived;
 
-        // public event PushReceivedDelegate OnPushReceived;
+        public delegate void PushOpenedDelegate(PushMessage message);
+        public event PushOpenedDelegate OnPushOpened;
 
-        // public delegate void InAppDeepLinkDelegate(Dictionary<string, object> message);
+        public delegate void InAppDeepLinkDelegate(Dictionary<string, object> message);
+        public event InAppDeepLinkDelegate OnInAppDeepLinkPressed;
 
-        // public event InAppDeepLinkDelegate OnInAppDeepLinkPressed;
-
-        // public delegate void InAppInboxUpdatedDelegate();
-
-        // public event InAppInboxUpdatedDelegate OnInAppInboxUpdated;
+        public delegate void InAppInboxUpdatedDelegate();
+        public event InAppInboxUpdatedDelegate OnInAppInboxUpdated;
 
         #region Statics
 
@@ -214,19 +214,29 @@ namespace OptimoveSdk
         }
 
 
-//         public void PushReceived(string message)
-//         {
-//             if (OnPushReceived == null)
-//             {
-//                 return;
-//             }
+        public void PushReceived(string message)
+        {
+            if (OnPushReceived == null)
+            {
+                return;
+            }
 
-//             var push = PushMessage.CreateFromJson(message);
+            var push = PushMessage.CreateFromJson(message);
 
-//             OnPushReceived(push);
-//         }
+            OnPushReceived(push);
+        }
 
-    //TODO: PushOpened?
+        public void PushOpened(string message)
+        {
+                if (OnPushOpened == null){
+                        return;
+                }
+
+                var push = PushMessage.CreateFromJson(message);
+
+                OnPushOpened(push);
+        }
+
 
         #endregion
 
@@ -244,30 +254,6 @@ namespace OptimoveSdk
                         //TODO
                 #endif
         }
-
-//         public void InAppDeepLinkPressed(string dataJson)
-//         {
-//             if (OnInAppDeepLinkPressed == null)
-//             {
-//                 return;
-//             }
-
-//             var data = MiniJSON.Json.Deserialize(dataJson) as Dictionary<string, object>;
-
-//             OnInAppDeepLinkPressed(data);
-//         }
-
-//         public void InAppInboxUpdated()
-//         {
-//             if (OnInAppInboxUpdated == null)
-//             {
-//                 return;
-//             }
-
-//             OnInAppInboxUpdated();
-//         }
-
-
 
         public List<InAppInboxItem> InAppGetInboxItems()
         {
@@ -326,6 +312,28 @@ namespace OptimoveSdk
                 #else
                         return false;
                 #endif
+        }
+
+        public void InAppDeepLinkPressed(string dataJson)//TODO: dictionary to model? not in Flutter, but in cordova
+        {
+            if (OnInAppDeepLinkPressed == null)
+            {
+                return;
+            }
+
+            var data = MiniJSON.Json.Deserialize(dataJson) as Dictionary<string, object>;
+
+            OnInAppDeepLinkPressed(data);
+        }
+
+        public void InAppInboxUpdated()
+        {
+            if (OnInAppInboxUpdated == null)
+            {
+                return;
+            }
+
+            OnInAppInboxUpdated();
         }
 
 

--- a/ExampleApp/Assets/Plugins/iOS/Bridging-Header.h
+++ b/ExampleApp/Assets/Plugins/iOS/Bridging-Header.h
@@ -1,7 +1,8 @@
-
-
-//copied from ProductModuleName-Swift.h
 @interface Optimove_Unity
+
+typedef void (^InboxSummaryResultHandler)(NSDictionary* _Nonnull);
+
+
 + (void)didFinishLaunching:(NSNotification * _Nonnull)notification unityVersion:String;
 
 + (void)reportEvent:(NSString * _Nonnull)type parameters:(NSDictionary * _Nullable) parameters;
@@ -12,5 +13,17 @@
 + (void)setUserEmail:(NSString * _Nonnull)email;
 + (NSString * _Nullable)getVisitorId;
 + (void)signOutUser;
+
++ (void)pushRegister;
++ (void)pushUnregister;
++ (void)inAppUpdateConsent:(BOOL)consented;
++ (NSMutableArray<NSDictionary*>* _Nonnull)inAppGetInboxItems;
++ (NSString * _Nonnull)inAppPresentInboxMessage:(int)messageId;
++ (BOOL)inAppDeleteMessageFromInbox:(int)messageId;
++ (BOOL)inAppMarkAsRead:(int)messageId;
++ (BOOL)inAppMarkAllInboxItemsAsRead;
++ (void)inAppGetInboxSummary:(NSString * _Nonnull)guid handler:(InboxSummaryResultHandler _Nonnull)handler;
+
+
 @end
 

--- a/ExampleApp/Assets/Plugins/iOS/InitializePluginManager.m
+++ b/ExampleApp/Assets/Plugins/iOS/InitializePluginManager.m
@@ -1,5 +1,5 @@
 #import "InitializePluginManager.h"
-#import "Bridging-Header.h"
+#import "Objc-swift-bridging-header.h"
 
 @implementation InitializePluginManager
 

--- a/ExampleApp/Assets/Plugins/iOS/Objc-swift-bridging-header.h
+++ b/ExampleApp/Assets/Plugins/iOS/Objc-swift-bridging-header.h
@@ -24,6 +24,4 @@ typedef void (^InboxSummaryResultHandler)(NSDictionary* _Nonnull);
 + (BOOL)inAppMarkAllInboxItemsAsRead;
 + (void)inAppGetInboxSummary:(NSString * _Nonnull)guid handler:(InboxSummaryResultHandler _Nonnull)handler;
 
-
 @end
-

--- a/ExampleApp/Assets/Plugins/iOS/Objc-swift-bridging-header.h.meta
+++ b/ExampleApp/Assets/Plugins/iOS/Objc-swift-bridging-header.h.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 28854b224ff7946acba08597d747a07e
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ExampleApp/Assets/Plugins/iOS/OptimovePluginInterface.h
+++ b/ExampleApp/Assets/Plugins/iOS/OptimovePluginInterface.h
@@ -1,5 +1,5 @@
-#ifndef UnityPluginBridge_h
-#define UnityPluginBridge_h
+#ifndef OptimovePluginInterface_h
+#define OptimovePluginInterface_h
 
 void OptimoveReportEvent(const char* type, const char* jsonData);
 void OptimoveReportScreenVisit(const char* screenTitle, const char* screenCategory);
@@ -19,6 +19,4 @@ BOOL OptimoveInAppMarkAsRead(int messageId);
 void OptimoveInAppGetInboxSummary(const char* guid);
 
 
-#endif /* UnityPluginBridge_h */
-
-
+#endif /* OptimovePluginInterface_h */

--- a/ExampleApp/Assets/Plugins/iOS/OptimovePluginInterface.h.meta
+++ b/ExampleApp/Assets/Plugins/iOS/OptimovePluginInterface.h.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bab8e596f2bbe40798e931d5bbfe5950
+guid: a8a5336df55624d9da4f4946126e8780
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/ExampleApp/Assets/Plugins/iOS/OptimovePluginInterface.m.meta
+++ b/ExampleApp/Assets/Plugins/iOS/OptimovePluginInterface.m.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6cf96b9d53c3b43fb844ae078a90ec61
+guid: 33bcd795d72114f80a760a1242c0111e
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/ExampleApp/Assets/Plugins/iOS/OptimoveSDKPlugin.swift
+++ b/ExampleApp/Assets/Plugins/iOS/OptimoveSDKPlugin.swift
@@ -1,5 +1,13 @@
 import OptimoveSDK
 
+enum InAppConsentStrategy: String {
+    case autoEnroll = "auto-enroll"
+    case explicitByUser = "explicit-by-user"
+    case disabled = "in-app-disabled"
+}
+
+typealias InboxSummaryResultHandler = ([AnyHashable : Any]) -> Void
+
 @objc(Optimove_Unity) class OptimoveSDKPlugin: NSObject {
 
     private static let optimoveCredentialsKey = "optimoveCredentials"
@@ -17,13 +25,28 @@ import OptimoveSDK
     static func didFinishLaunching(notification: Notification, unityVersion: String) {
 
         let configValues = [
-            "optimoveCredentials": "<yours>",
-            "optimoveMobileCredentials": "<yours>"
+            "optimoveCredentials": "",
+            "optimoveMobileCredentials": "<yours>",
+            "optimoveInAppConsentStrategy": "explicit-by-user"
         ]
 
         guard let builder = getConfigBuilder(configValues: configValues) else{
             return
         };
+
+        switch(configValues[inAppConsentStrategy]){
+            case InAppConsentStrategy.autoEnroll.rawValue:
+                builder.enableInAppMessaging(inAppConsentStrategy:OptimoveSDK.InAppConsentStrategy.autoEnroll);
+                break
+            case InAppConsentStrategy.explicitByUser.rawValue:
+                builder.enableInAppMessaging(inAppConsentStrategy:OptimoveSDK.InAppConsentStrategy.explicitByUser);
+                break
+            case InAppConsentStrategy.disabled.rawValue:
+                break
+            default:
+                print("Invalid inApp consent strategy")
+                return
+        }
 
         overrideInstallInfo(builder: builder, unityVersion:unityVersion)
 
@@ -111,4 +134,130 @@ import OptimoveSDK
     static func signOutUser() {
         Optimove.signOutUser()
     }
+
+    // ========================== MESSAGING ==========================
+
+    @objc(pushRegister)
+    static func pushRegister() {
+        Optimove.shared.pushRequestDeviceToken()
+    }
+
+    @objc(pushUnregister)
+    static func pushUnregister() {
+        Optimove.shared.pushUnregister()
+    }
+
+    @objc(inAppUpdateConsent:)
+    static func inAppUpdateConsent(consented: Bool) {
+        OptimoveInApp.updateConsent(forUser: consented)
+    }
+
+    @objc(inAppGetInboxItems)
+    static func inAppGetInboxItems() -> [[String: Any]] {
+
+        let inboxItems = OptimoveInApp.getInboxItems()
+        var items = [[String : Any]]()
+
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+        for item in inboxItems {
+            let dict: [String: Any] = [
+                "id": item.id,
+                "title": item.title,
+                "subtitle": item.subtitle,
+                "availableFrom": item.availableFrom != nil ? formatter.string(from: item.availableFrom!) : NSNull(),
+                "availableTo": item.availableTo != nil ? formatter.string(from: item.availableTo!) : NSNull(),
+                "dismissedAt": item.dismissedAt != nil ? formatter.string(from: item.dismissedAt!) : NSNull(),
+                "isRead": item.isRead(),
+                "sentAt": formatter.string(from: item.sentAt),
+                "imageUrl": item.getImageUrl()?.absoluteString ?? NSNull(),
+                "data": item.data ?? NSNull()
+            ]
+
+            items.append(dict)
+        }
+
+        return items
+    }
+
+    @objc(inAppPresentInboxMessage:)
+    static func inAppPresentInboxMessage(messageId: Int64) -> String {
+        let inboxItems = OptimoveInApp.getInboxItems()
+
+        var presentationResult: InAppMessagePresentationResult = .FAILED
+        for msg in inboxItems {
+            if (msg.id != messageId){
+                continue
+            }
+
+            presentationResult = OptimoveInApp.presentInboxMessage(item: msg)
+
+            break;
+        }
+
+        return presentationResult.rawValue
+    }
+
+    @objc(inAppDeleteMessageFromInbox:)
+    static func inAppDeleteMessageFromInbox(messageId: Int64) -> Bool {
+        let inboxItems = OptimoveInApp.getInboxItems()
+
+        var result = false
+        for msg in inboxItems {
+            if msg.id != messageId {
+                continue
+            }
+
+            result = OptimoveInApp.deleteMessageFromInbox(item: msg)
+
+            break
+        }
+
+        return result
+    }
+
+    @objc(inAppMarkAsRead:)
+    static func inAppMarkAsRead(messageId: Int64) -> Bool {
+      let inboxItems = OptimoveInApp.getInboxItems()
+
+      var result = false
+      for msg in inboxItems {
+          if msg.id != messageId {
+              continue
+          }
+
+          result = OptimoveInApp.markAsRead(item: msg)
+          break
+      }
+
+      return result
+    }
+
+    @objc(inAppMarkAllInboxItemsAsRead)
+    static func inAppMarkAllInboxItemsAsRead() -> Bool {
+        return OptimoveInApp.markAllInboxItemsAsRead()
+    }
+
+    @objc(inAppGetInboxSummary:handler:)
+    static func inAppGetInboxSummary(guid: String, handler: @escaping InboxSummaryResultHandler) {
+        print("*************** CALLING")
+        OptimoveInApp.getInboxSummaryAsync { summary in
+            var dict: [String: Any] = [
+                "guid": guid,
+                "success": false
+            ]
+
+            if let summary = summary {
+                dict["totalCount"] = summary.totalCount
+                dict["unreadCount"] = summary.unreadCount
+                dict["success"] = true
+            }
+
+            handler(dict)
+        }
+    }
 }
+
+
+

--- a/ExampleApp/Assets/Plugins/iOS/Swift-objc-bridging-header.h
+++ b/ExampleApp/Assets/Plugins/iOS/Swift-objc-bridging-header.h
@@ -1,0 +1,9 @@
+#ifndef Swift_objc_bridging_header_h
+#define Swift_objc_bridging_header_h
+
+void OptimoveCallUnityInAppDeepLinkPressed(NSDictionary* press);
+void OptimoveCallUnityInAppInboxUpdated();
+void OptimoveCallUnityPushOpened(NSDictionary* push);
+void OptimoveCallUnityPushReceived(NSDictionary* push);
+
+#endif /* Swift_objc_bridging_header_h */

--- a/ExampleApp/Assets/Plugins/iOS/Swift-objc-bridging-header.h.meta
+++ b/ExampleApp/Assets/Plugins/iOS/Swift-objc-bridging-header.h.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 469177d5c29a6416baf3d6cf47f443b7
+guid: 98552e9597e9e4290aae4729a061566b
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/ExampleApp/Assets/Plugins/iOS/UnityFramework.modulemap
+++ b/ExampleApp/Assets/Plugins/iOS/UnityFramework.modulemap
@@ -1,0 +1,12 @@
+framework module UnityFramework {
+  umbrella header "UnityFramework.h"
+
+  export *
+  module * { export * }
+
+  module UnityPluginBridgeInterface {
+      header "Swift-objc-bridging-header.h"
+
+      export *
+  }
+}

--- a/ExampleApp/Assets/Plugins/iOS/UnityFramework.modulemap.meta
+++ b/ExampleApp/Assets/Plugins/iOS/UnityFramework.modulemap.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b8ab7e8deec0d4dbfaea1d1c517097bb
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ExampleApp/Assets/Plugins/iOS/UnityPluginBridge.h
+++ b/ExampleApp/Assets/Plugins/iOS/UnityPluginBridge.h
@@ -8,6 +8,16 @@ void OptimoveSetUserId(const char* userId);
 void OptimoveSetUserEmail(const char* email);
 char* OptimoveGetVisitorId();
 void OptimoveSignOutUser();
+void OptimoveUpdatePushRegistration(int status);
+void OptimoveInAppUpdateConsentForUser(int consented);
+
+
+char* OptimoveInAppGetInboxItems();
+char* OptimoveInAppPresentInboxMessage(int messageId);
+BOOL OptimoveInAppDeleteMessageFromInbox(int messageId);
+BOOL OptimoveInAppMarkAsRead(int messageId);
+void OptimoveInAppGetInboxSummary(const char* guid);
+
 
 #endif /* UnityPluginBridge_h */
 

--- a/ExampleApp/Assets/Scenes/SampleScene.unity
+++ b/ExampleApp/Assets/Scenes/SampleScene.unity
@@ -158,11 +158,11 @@ RectTransform:
   m_Father: {fileID: 2070720297}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 2, y: -350}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 225, y: -170}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &8948377
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -271,20 +271,20 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 13552249}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 312623313}
-  m_Father: {fileID: 101794940}
+  m_Father: {fileID: 536181274}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 256, y: -499}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 497, y: -1200}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &13552251
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -401,13 +401,13 @@ RectTransform:
   - {fileID: 799501092}
   - {fileID: 1828274500}
   - {fileID: 1062603537}
-  m_Father: {fileID: 101794940}
+  m_Father: {fileID: 536181274}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -233.00002, y: 826.0999}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: -0.00029659, y: 621.4473}
+  m_SizeDelta: {x: 732.58, y: 347.2379}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &93529738
 GameObject:
@@ -521,13 +521,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 72581426}
-  - {fileID: 2009999457}
-  - {fileID: 1055338968}
-  - {fileID: 2070720297}
-  - {fileID: 899865302}
-  - {fileID: 1708205103}
-  - {fileID: 13552250}
+  - {fileID: 2131212019}
   m_Father: {fileID: 1900725529}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -964,11 +958,11 @@ RectTransform:
   m_Father: {fileID: 2070720297}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 247, y: -233}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 450, y: -80}
   m_SizeDelta: {x: 220, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &193680481
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1371,6 +1365,49 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 448048709}
   m_CullTransparentMesh: 1
+--- !u!1 &536181273
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 536181274}
+  m_Layer: 0
+  m_Name: ContentContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &536181274
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536181273}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 72581426}
+  - {fileID: 2009999457}
+  - {fileID: 1055338968}
+  - {fileID: 2070720297}
+  - {fileID: 899865302}
+  - {fileID: 1708205103}
+  - {fileID: 13552250}
+  m_Father: {fileID: 2131212019}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00045776, y: 0.00003889196}
+  m_SizeDelta: {x: 732.58, y: 1630.9}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &550636393
 GameObject:
   m_ObjectHideFlags: 0
@@ -1727,11 +1764,11 @@ RectTransform:
   m_Father: {fileID: 2070720297}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -174, y: -144}
-  m_SizeDelta: {x: 350, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 300, y: 60}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &714035803
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1874,11 +1911,11 @@ RectTransform:
   m_Father: {fileID: 72581426}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 50, y: -21.1}
-  m_SizeDelta: {x: 350, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 300, y: 60}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &725161196
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2182,11 +2219,11 @@ RectTransform:
   m_Father: {fileID: 2009999457}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 491.6, y: 193.70007}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 450, y: -90}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!1 &799501091
 GameObject:
   m_ObjectHideFlags: 0
@@ -2223,11 +2260,11 @@ RectTransform:
   m_Father: {fileID: 72581426}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 50, y: -196.5}
-  m_SizeDelta: {x: 350, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -200}
+  m_SizeDelta: {x: 300, y: 60}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &799501093
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2369,7 +2406,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 9.999985, y: -0.5000076}
+  m_AnchoredPosition: {x: 9.999985, y: -0.5}
   m_SizeDelta: {x: -20, y: -13}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &815943589
@@ -2449,11 +2486,11 @@ RectTransform:
   m_Father: {fileID: 2009999457}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 232.7, y: 196.40007}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 225, y: -90}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &833239329
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2571,11 +2608,11 @@ RectTransform:
   m_Father: {fileID: 1055338968}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -254, y: 89}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &861175181
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2842,17 +2879,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 899865301}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 101794940}
+  m_Father: {fileID: 536181274}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -129.00002, y: 37.700012}
+  m_AnchoredPosition: {x: 103.999954, y: -788.39996}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &899865303
@@ -3076,7 +3113,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1055338967}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -3085,14 +3122,14 @@ RectTransform:
   - {fileID: 1256248860}
   - {fileID: 2031151767}
   - {fileID: 1255868250}
-  m_Father: {fileID: 101794940}
+  m_Father: {fileID: 536181274}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.14600801, y: 31.5229}
+  m_SizeDelta: {x: 732.29, y: 145.1843}
+  m_Pivot: {x: 0.5, y: 0.5763131}
 --- !u!1 &1062603536
 GameObject:
   m_ObjectHideFlags: 0
@@ -3128,11 +3165,11 @@ RectTransform:
   m_Father: {fileID: 72581426}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -25, y: -273.7}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -277}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1062603538
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3250,11 +3287,11 @@ RectTransform:
   m_Father: {fileID: 1055338968}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 255, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -85}
   m_SizeDelta: {x: 217, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1255868251
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3372,11 +3409,11 @@ RectTransform:
   m_Father: {fileID: 1055338968}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 87}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 225, y: 0}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1256248861
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3576,11 +3613,11 @@ RectTransform:
   m_Father: {fileID: 2009999457}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 236, y: 94.20007}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 225, y: -170}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!1 &1335075592
 GameObject:
   m_ObjectHideFlags: 0
@@ -3936,11 +3973,11 @@ RectTransform:
   m_Father: {fileID: 2070720297}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -248, y: -232.99998}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -80}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1499535980
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4058,11 +4095,11 @@ RectTransform:
   m_Father: {fileID: 2070720297}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -233}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 225, y: -80}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1522597163
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4260,11 +4297,11 @@ RectTransform:
   m_Father: {fileID: 72581426}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -102.4}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -81}
   m_SizeDelta: {x: 250, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1573501217
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4383,11 +4420,11 @@ RectTransform:
   m_Father: {fileID: 2009999457}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 420, y: 292.20007}
-  m_SizeDelta: {x: 350, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 366, y: 0}
+  m_SizeDelta: {x: 300, y: 60}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1633890587
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4529,11 +4566,11 @@ RectTransform:
   m_Father: {fileID: 2070720297}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 247, y: -350}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 450, y: -170}
   m_SizeDelta: {x: 220, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1669279626
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4802,20 +4839,20 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1708205102}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 610257536}
-  m_Father: {fileID: 101794940}
+  m_Father: {fileID: 536181274}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 8.1084, y: -635}
-  m_SizeDelta: {x: 696.426, y: 169.4409}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -1266.1951}
+  m_SizeDelta: {x: 696.426, y: 364.705}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1708205104
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4995,11 +5032,11 @@ RectTransform:
   m_Father: {fileID: 2009999457}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -25, y: 95.80008}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -170}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1776605919
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5198,11 +5235,11 @@ RectTransform:
   m_Father: {fileID: 72581426}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 420, y: -196.20006}
-  m_SizeDelta: {x: 350, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 366, y: -200}
+  m_SizeDelta: {x: 300, y: 60}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1828274501
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5345,11 +5382,11 @@ RectTransform:
   m_Father: {fileID: 2009999457}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 50, y: 293}
-  m_SizeDelta: {x: 350, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 300, y: 60}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1850861111
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5805,11 +5842,11 @@ RectTransform:
   m_Father: {fileID: 72581426}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 420, y: -20.4}
-  m_SizeDelta: {x: 350, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 366, y: 0}
+  m_SizeDelta: {x: 300, y: 60}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1907261175
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6099,7 +6136,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2009999456}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -6111,13 +6148,13 @@ RectTransform:
   - {fileID: 777054679}
   - {fileID: 1776605918}
   - {fileID: 1306747328}
-  m_Father: {fileID: 101794940}
+  m_Father: {fileID: 536181274}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -233, y: 130.59998}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchorMin: {x: 0, y: 0.73800004}
+  m_AnchorMax: {x: 0, y: 0.73800004}
+  m_AnchoredPosition: {x: 365.9975, y: -194.01}
+  m_SizeDelta: {x: 732.58, y: 387.98}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2031151766
 GameObject:
@@ -6154,11 +6191,11 @@ RectTransform:
   m_Father: {fileID: 1055338968}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 255, y: 89}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 450, y: 0}
   m_SizeDelta: {x: 217, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &2031151768
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6344,7 +6381,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2070720296}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -6356,13 +6393,13 @@ RectTransform:
   - {fileID: 2121683642}
   - {fileID: 8948376}
   - {fileID: 1669279625}
-  m_Father: {fileID: 101794940}
+  m_Father: {fileID: 536181274}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchoredPosition: {x: -0.29184, y: -214.46039}
+  m_SizeDelta: {x: 732.58, y: 248.8428}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2078669445
 GameObject:
@@ -6399,11 +6436,11 @@ RectTransform:
   m_Father: {fileID: 2009999457}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -25, y: 193.90007}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -90}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &2078669447
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6521,11 +6558,11 @@ RectTransform:
   m_Father: {fileID: 2070720297}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -248, y: -350}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -170}
   m_SizeDelta: {x: 200, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &2121683643
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6608,3 +6645,125 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2121683641}
   m_CullTransparentMesh: 1
+--- !u!1 &2131212018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2131212019}
+  - component: {fileID: 2131212022}
+  - component: {fileID: 2131212021}
+  - component: {fileID: 2131212020}
+  - component: {fileID: 2131212023}
+  m_Layer: 0
+  m_Name: ScrollPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2131212019
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2131212018}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 536181274}
+  m_Father: {fileID: 101794940}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 5.3157, y: 23.443}
+  m_SizeDelta: {x: 732.5817, y: 1635.3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2131212020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2131212018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2784314, g: 0.2784314, b: 0.2784314, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2131212021
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2131212018}
+  m_CullTransparentMesh: 1
+--- !u!114 &2131212022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2131212018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 536181274}
+  m_Horizontal: 0
+  m_Vertical: 1
+  m_MovementType: 1
+  m_Elasticity: 0.1
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 1
+  m_Viewport: {fileID: 0}
+  m_HorizontalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 0}
+  m_HorizontalScrollbarVisibility: 0
+  m_VerticalScrollbarVisibility: 0
+  m_HorizontalScrollbarSpacing: 0
+  m_VerticalScrollbarSpacing: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2131212023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2131212018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1

--- a/ExampleApp/Assets/Scenes/SampleScene.unity
+++ b/ExampleApp/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,128 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &8948375
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8948376}
+  - component: {fileID: 8948379}
+  - component: {fileID: 8948378}
+  - component: {fileID: 8948377}
+  m_Layer: 0
+  m_Name: Button_MarkAllInboxItemsRead
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8948376
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8948375}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 557974230}
+  m_Father: {fileID: 2070720297}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 2, y: -350}
+  m_SizeDelta: {x: 200, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8948377
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8948375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8948378}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &8948378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8948375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &8948379
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8948375}
+  m_CullTransparentMesh: 1
 --- !u!1 &13552249
 GameObject:
   m_ObjectHideFlags: 0
@@ -156,7 +278,7 @@ RectTransform:
   m_Children:
   - {fileID: 312623313}
   m_Father: {fileID: 101794940}
-  m_RootOrder: 4
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -275,10 +397,10 @@ RectTransform:
   m_Children:
   - {fileID: 725161195}
   - {fileID: 1907261174}
-  - {fileID: 1062603537}
   - {fileID: 1573501216}
-  - {fileID: 1828274500}
   - {fileID: 799501092}
+  - {fileID: 1828274500}
+  - {fileID: 1062603537}
   m_Father: {fileID: 101794940}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -401,6 +523,8 @@ RectTransform:
   m_Children:
   - {fileID: 72581426}
   - {fileID: 2009999457}
+  - {fileID: 1055338968}
+  - {fileID: 2070720297}
   - {fileID: 899865302}
   - {fileID: 1708205103}
   - {fileID: 13552250}
@@ -485,6 +609,166 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 86a2739db4f074c45b07dbbdb40f952c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &106712062
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 106712063}
+  - component: {fileID: 106712065}
+  - component: {fileID: 106712064}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &106712063
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106712062}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1669279625}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &106712064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106712062}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Get inbox summary
+--- !u!222 &106712065
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106712062}
+  m_CullTransparentMesh: 1
+--- !u!1 &135896730
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 135896731}
+  - component: {fileID: 135896733}
+  - component: {fileID: 135896732}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &135896731
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135896730}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1499535979}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &135896732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135896730}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Present inbox message
+--- !u!222 &135896733
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135896730}
+  m_CullTransparentMesh: 1
 --- !u!1 &158516429
 GameObject:
   m_ObjectHideFlags: 0
@@ -644,6 +928,128 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 171892361}
+  m_CullTransparentMesh: 1
+--- !u!1 &193680479
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 193680480}
+  - component: {fileID: 193680483}
+  - component: {fileID: 193680482}
+  - component: {fileID: 193680481}
+  m_Layer: 0
+  m_Name: Button_MarkInboxItemRead
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &193680480
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 193680479}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1335075593}
+  m_Father: {fileID: 2070720297}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 247, y: -233}
+  m_SizeDelta: {x: 220, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &193680481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 193680479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 193680482}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &193680482
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 193680479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &193680483
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 193680479}
   m_CullTransparentMesh: 1
 --- !u!1 &312623312
 GameObject:
@@ -805,6 +1211,86 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 358755925}
   m_CullTransparentMesh: 1
+--- !u!1 &384800471
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 384800472}
+  - component: {fileID: 384800474}
+  - component: {fileID: 384800473}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &384800472
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 384800471}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1522597162}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &384800473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 384800471}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Delete inbox message
+--- !u!222 &384800474
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 384800471}
+  m_CullTransparentMesh: 1
 --- !u!1 &448048709
 GameObject:
   m_ObjectHideFlags: 0
@@ -964,6 +1450,86 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 550636393}
+  m_CullTransparentMesh: 1
+--- !u!1 &557974229
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 557974230}
+  - component: {fileID: 557974232}
+  - component: {fileID: 557974231}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &557974230
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 557974229}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8948376}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &557974231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 557974229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Mark all inbox items read
+--- !u!222 &557974232
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 557974229}
   m_CullTransparentMesh: 1
 --- !u!1 &610257535
 GameObject:
@@ -1125,6 +1691,153 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 622039420}
   m_CullTransparentMesh: 1
+--- !u!1 &714035801
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 714035802}
+  - component: {fileID: 714035805}
+  - component: {fileID: 714035804}
+  - component: {fileID: 714035803}
+  m_Layer: 0
+  m_Name: Input_InboxItemId
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &714035802
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 714035801}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1856433242}
+  - {fileID: 869426880}
+  m_Father: {fileID: 2070720297}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -174, y: -144}
+  m_SizeDelta: {x: 350, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &714035803
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 714035801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d199490a83bb2b844b9695cbf13b01ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 714035804}
+  m_TextComponent: {fileID: 869426881}
+  m_Placeholder: {fileID: 1856433243}
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_CharacterValidation: 0
+  m_CharacterLimit: 0
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDidEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_ShouldActivateOnSelect: 1
+--- !u!114 &714035804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 714035801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &714035805
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 714035801}
+  m_CullTransparentMesh: 1
 --- !u!1 &725161194
 GameObject:
   m_ObjectHideFlags: 0
@@ -1163,7 +1876,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 50.6, y: -21.1}
+  m_AnchoredPosition: {x: 50, y: -21.1}
   m_SizeDelta: {x: 350, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &725161196
@@ -1467,11 +2180,11 @@ RectTransform:
   m_Children:
   - {fileID: 550636394}
   m_Father: {fileID: 2009999457}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 491.6, y: 218.2}
+  m_AnchoredPosition: {x: 491.6, y: 193.70007}
   m_SizeDelta: {x: 200, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &799501091
@@ -1508,11 +2221,11 @@ RectTransform:
   - {fileID: 1393638751}
   - {fileID: 815943588}
   m_Father: {fileID: 72581426}
-  m_RootOrder: 5
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 49.7, y: -196.5}
+  m_AnchoredPosition: {x: 50, y: -196.5}
   m_SizeDelta: {x: 350, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &799501093
@@ -1734,11 +2447,11 @@ RectTransform:
   m_Children:
   - {fileID: 93529739}
   m_Father: {fileID: 2009999457}
-  m_RootOrder: 6
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 232.7, y: 220.9}
+  m_AnchoredPosition: {x: 232.7, y: 196.40007}
   m_SizeDelta: {x: 200, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &833239329
@@ -1823,6 +2536,128 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 833239327}
   m_CullTransparentMesh: 1
+--- !u!1 &861175179
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 861175180}
+  - component: {fileID: 861175183}
+  - component: {fileID: 861175182}
+  - component: {fileID: 861175181}
+  m_Layer: 0
+  m_Name: Button_PushRegister
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &861175180
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 861175179}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1965528075}
+  m_Father: {fileID: 1055338968}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -254, y: 89}
+  m_SizeDelta: {x: 200, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &861175181
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 861175179}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 861175182}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &861175182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 861175179}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &861175183
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 861175179}
+  m_CullTransparentMesh: 1
 --- !u!1 &864131635
 GameObject:
   m_ObjectHideFlags: 0
@@ -1903,6 +2738,86 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 864131635}
   m_CullTransparentMesh: 1
+--- !u!1 &869426879
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 869426880}
+  - component: {fileID: 869426882}
+  - component: {fileID: 869426881}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &869426880
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 869426879}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 714035802}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &869426881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 869426879}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &869426882
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 869426879}
+  m_CullTransparentMesh: 1
 --- !u!1 &899865301
 GameObject:
   m_ObjectHideFlags: 0
@@ -1933,7 +2848,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 101794940}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1952,19 +2867,30 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: caa924f4241f145348405cd3855c6b3e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_userIdInput: {fileID: 1850861111}
-  m_userEmailInput: {fileID: 1633890587}
   m_screenName: {fileID: 725161196}
   m_screenCategory: {fileID: 1907261175}
   m_eventType: {fileID: 799501093}
   m_eventProps: {fileID: 1828274501}
   m_reportScreenVisit: {fileID: 1573501217}
   m_reportEvent: {fileID: 1062603538}
+  m_userIdInput: {fileID: 1850861111}
+  m_userEmailInput: {fileID: 1633890587}
   m_setUserIdButton: {fileID: 2078669447}
   m_setUserEmailButton: {fileID: 833239329}
   m_registerUserButton: {fileID: 777054676}
   m_getVisitorId: {fileID: 1776605919}
   m_signOutUser: {fileID: 1306747325}
+  m_pushRegister: {fileID: 861175181}
+  m_pushUnregister: {fileID: 1256248861}
+  m_inAppConsentTrue: {fileID: 2031151768}
+  m_inAppConsentFalse: {fileID: 1255868251}
+  m_inboxItemId: {fileID: 714035803}
+  m_presentInboxMessage: {fileID: 1499535980}
+  m_deleteInboxMessage: {fileID: 1522597163}
+  m_markItemAsRead: {fileID: 193680481}
+  m_getInboxItems: {fileID: 2121683643}
+  m_MarkAllAsRead: {fileID: 8948377}
+  m_getInboxSummary: {fileID: 1669279626}
   m_clearOutput: {fileID: 13552251}
   m_output: {fileID: 610257537}
 --- !u!1 &948693183
@@ -2127,6 +3053,46 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 991318113}
   m_CullTransparentMesh: 1
+--- !u!1 &1055338967
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1055338968}
+  m_Layer: 0
+  m_Name: Registrations
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1055338968
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1055338967}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 861175180}
+  - {fileID: 1256248860}
+  - {fileID: 2031151767}
+  - {fileID: 1255868250}
+  m_Father: {fileID: 101794940}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1062603536
 GameObject:
   m_ObjectHideFlags: 0
@@ -2160,11 +3126,11 @@ RectTransform:
   m_Children:
   - {fileID: 1552295970}
   m_Father: {fileID: 72581426}
-  m_RootOrder: 2
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -24.7, y: -273.7}
+  m_AnchoredPosition: {x: -25, y: -273.7}
   m_SizeDelta: {x: 200, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1062603538
@@ -2248,6 +3214,250 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1062603536}
+  m_CullTransparentMesh: 1
+--- !u!1 &1255868249
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1255868250}
+  - component: {fileID: 1255868253}
+  - component: {fileID: 1255868252}
+  - component: {fileID: 1255868251}
+  m_Layer: 0
+  m_Name: Button_InAppConsentFalse
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1255868250
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1255868249}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1474119055}
+  m_Father: {fileID: 1055338968}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 255, y: 0}
+  m_SizeDelta: {x: 217, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1255868251
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1255868249}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1255868252}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1255868252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1255868249}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1255868253
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1255868249}
+  m_CullTransparentMesh: 1
+--- !u!1 &1256248859
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1256248860}
+  - component: {fileID: 1256248863}
+  - component: {fileID: 1256248862}
+  - component: {fileID: 1256248861}
+  m_Layer: 0
+  m_Name: Button_PushUnregister
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1256248860
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1256248859}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1788671059}
+  m_Father: {fileID: 1055338968}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 87}
+  m_SizeDelta: {x: 200, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1256248861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1256248859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1256248862}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1256248862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1256248859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1256248863
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1256248859}
   m_CullTransparentMesh: 1
 --- !u!1 &1306747324
 GameObject:
@@ -2364,13 +3574,93 @@ RectTransform:
   m_Children:
   - {fileID: 1900140584}
   m_Father: {fileID: 2009999457}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -23.7, y: 118.7}
+  m_AnchoredPosition: {x: 236, y: 94.20007}
   m_SizeDelta: {x: 200, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1335075592
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1335075593}
+  - component: {fileID: 1335075595}
+  - component: {fileID: 1335075594}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1335075593
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1335075592}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 193680480}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1335075594
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1335075592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Mark inbox item read
+--- !u!222 &1335075595
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1335075592}
+  m_CullTransparentMesh: 1
 --- !u!1 &1393638750
 GameObject:
   m_ObjectHideFlags: 0
@@ -2531,6 +3821,330 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1419887043}
   m_CullTransparentMesh: 1
+--- !u!1 &1474119054
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1474119055}
+  - component: {fileID: 1474119057}
+  - component: {fileID: 1474119056}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1474119055
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1474119054}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1255868250}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1474119056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1474119054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: In-app consent false
+--- !u!222 &1474119057
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1474119054}
+  m_CullTransparentMesh: 1
+--- !u!1 &1499535978
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1499535979}
+  - component: {fileID: 1499535982}
+  - component: {fileID: 1499535981}
+  - component: {fileID: 1499535980}
+  m_Layer: 0
+  m_Name: Button_PresentInboxMessage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1499535979
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1499535978}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 135896731}
+  m_Father: {fileID: 2070720297}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -248, y: -232.99998}
+  m_SizeDelta: {x: 200, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1499535980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1499535978}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1499535981}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1499535981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1499535978}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1499535982
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1499535978}
+  m_CullTransparentMesh: 1
+--- !u!1 &1522597161
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1522597162}
+  - component: {fileID: 1522597165}
+  - component: {fileID: 1522597164}
+  - component: {fileID: 1522597163}
+  m_Layer: 0
+  m_Name: Button_DeleteInboxMessage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1522597162
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522597161}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 384800472}
+  m_Father: {fileID: 2070720297}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -233}
+  m_SizeDelta: {x: 200, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1522597163
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522597161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1522597164}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1522597164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522597161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1522597165
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522597161}
+  m_CullTransparentMesh: 1
 --- !u!1 &1552295969
 GameObject:
   m_ObjectHideFlags: 0
@@ -2644,7 +4258,7 @@ RectTransform:
   m_Children:
   - {fileID: 358755926}
   m_Father: {fileID: 72581426}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2771,7 +4385,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 425.6, y: 316.7}
+  m_AnchoredPosition: {x: 420, y: 292.20007}
   m_SizeDelta: {x: 350, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1633890587
@@ -2879,6 +4493,208 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1633890585}
+  m_CullTransparentMesh: 1
+--- !u!1 &1669279624
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1669279625}
+  - component: {fileID: 1669279628}
+  - component: {fileID: 1669279627}
+  - component: {fileID: 1669279626}
+  m_Layer: 0
+  m_Name: Button_GetInboxSummary
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1669279625
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1669279624}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 106712063}
+  m_Father: {fileID: 2070720297}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 247, y: -350}
+  m_SizeDelta: {x: 220, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1669279626
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1669279624}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1669279627}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1669279627
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1669279624}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1669279628
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1669279624}
+  m_CullTransparentMesh: 1
+--- !u!1 &1693393603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1693393604}
+  - component: {fileID: 1693393606}
+  - component: {fileID: 1693393605}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1693393604
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1693393603}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2121683642}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1693393605
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1693393603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Get inbox items
+--- !u!222 &1693393606
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1693393603}
   m_CullTransparentMesh: 1
 --- !u!1 &1699016080
 GameObject:
@@ -2993,7 +4809,7 @@ RectTransform:
   m_Children:
   - {fileID: 610257536}
   m_Father: {fileID: 101794940}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3064,6 +4880,86 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1708205102}
   m_CullTransparentMesh: 1
+--- !u!1 &1763719714
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1763719715}
+  - component: {fileID: 1763719717}
+  - component: {fileID: 1763719716}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1763719715
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1763719714}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2031151767}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1763719716
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1763719714}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: In-app consent true
+--- !u!222 &1763719717
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1763719714}
+  m_CullTransparentMesh: 1
 --- !u!1 &1776605917
 GameObject:
   m_ObjectHideFlags: 0
@@ -3097,11 +4993,11 @@ RectTransform:
   m_Children:
   - {fileID: 1419887044}
   m_Father: {fileID: 2009999457}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 231.70001, y: 120.3}
+  m_AnchoredPosition: {x: -25, y: 95.80008}
   m_SizeDelta: {x: 200, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1776605919
@@ -3186,6 +5082,86 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1776605917}
   m_CullTransparentMesh: 1
+--- !u!1 &1788671058
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1788671059}
+  - component: {fileID: 1788671061}
+  - component: {fileID: 1788671060}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1788671059
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1788671058}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1256248860}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1788671060
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1788671058}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Push unregister
+--- !u!222 &1788671061
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1788671058}
+  m_CullTransparentMesh: 1
 --- !u!1 &1828274499
 GameObject:
   m_ObjectHideFlags: 0
@@ -3224,7 +5200,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 428.2, y: -196.20006}
+  m_AnchoredPosition: {x: 420, y: -196.20006}
   m_SizeDelta: {x: 350, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1828274501
@@ -3371,7 +5347,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 47.2, y: 317.5}
+  m_AnchoredPosition: {x: 50, y: 293}
   m_SizeDelta: {x: 350, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1850861111
@@ -3479,6 +5455,86 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1850861109}
+  m_CullTransparentMesh: 1
+--- !u!1 &1856433241
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1856433242}
+  - component: {fileID: 1856433244}
+  - component: {fileID: 1856433243}
+  m_Layer: 0
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1856433242
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1856433241}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 714035802}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1856433243
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1856433241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0.5}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 2
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Inbox item id
+--- !u!222 &1856433244
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1856433241}
   m_CullTransparentMesh: 1
 --- !u!1 &1900140583
 GameObject:
@@ -3751,7 +5807,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 423.3, y: -20.4}
+  m_AnchoredPosition: {x: 420, y: -20.4}
   m_SizeDelta: {x: 350, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1907261175
@@ -3859,6 +5915,86 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1907261173}
+  m_CullTransparentMesh: 1
+--- !u!1 &1965528074
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1965528075}
+  - component: {fileID: 1965528077}
+  - component: {fileID: 1965528076}
+  m_Layer: 0
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1965528075
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965528074}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 861175180}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1965528076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965528074}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Push register
+--- !u!222 &1965528077
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965528074}
   m_CullTransparentMesh: 1
 --- !u!1 &1974651981
 GameObject:
@@ -3970,19 +6106,141 @@ RectTransform:
   m_Children:
   - {fileID: 1850861110}
   - {fileID: 1633890586}
+  - {fileID: 2078669446}
+  - {fileID: 833239328}
   - {fileID: 777054679}
   - {fileID: 1776605918}
-  - {fileID: 2078669446}
   - {fileID: 1306747328}
-  - {fileID: 833239328}
   m_Father: {fileID: 101794940}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -231.00002, y: 130.59998}
+  m_AnchoredPosition: {x: -233, y: 130.59998}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2031151766
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2031151767}
+  - component: {fileID: 2031151770}
+  - component: {fileID: 2031151769}
+  - component: {fileID: 2031151768}
+  m_Layer: 0
+  m_Name: Button_InAppConsentTrue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2031151767
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031151766}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1763719715}
+  m_Father: {fileID: 1055338968}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 255, y: 89}
+  m_SizeDelta: {x: 217, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2031151768
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031151766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2031151769}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2031151769
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031151766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2031151770
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031151766}
+  m_CullTransparentMesh: 1
 --- !u!1 &2056194393
 GameObject:
   m_ObjectHideFlags: 0
@@ -4063,6 +6321,49 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2056194393}
   m_CullTransparentMesh: 1
+--- !u!1 &2070720296
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2070720297}
+  m_Layer: 0
+  m_Name: Inbox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2070720297
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2070720296}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 714035802}
+  - {fileID: 1499535979}
+  - {fileID: 1522597162}
+  - {fileID: 193680480}
+  - {fileID: 2121683642}
+  - {fileID: 8948376}
+  - {fileID: 1669279625}
+  m_Father: {fileID: 101794940}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2078669445
 GameObject:
   m_ObjectHideFlags: 0
@@ -4096,11 +6397,11 @@ RectTransform:
   m_Children:
   - {fileID: 448048710}
   m_Father: {fileID: 2009999457}
-  m_RootOrder: 4
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -22.8, y: 218.4}
+  m_AnchoredPosition: {x: -25, y: 193.90007}
   m_SizeDelta: {x: 200, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2078669447
@@ -4184,4 +6485,126 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2078669445}
+  m_CullTransparentMesh: 1
+--- !u!1 &2121683641
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2121683642}
+  - component: {fileID: 2121683645}
+  - component: {fileID: 2121683644}
+  - component: {fileID: 2121683643}
+  m_Layer: 0
+  m_Name: Button_GetInboxItems
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2121683642
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2121683641}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1693393604}
+  m_Father: {fileID: 2070720297}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -248, y: -350}
+  m_SizeDelta: {x: 200, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2121683643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2121683641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2121683644}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2121683644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2121683641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2121683645
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2121683641}
   m_CullTransparentMesh: 1

--- a/ExampleApp/Assets/Scenes/SampleScene.unity
+++ b/ExampleApp/Assets/Scenes/SampleScene.unity
@@ -282,7 +282,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 497, y: -1200}
+  m_AnchoredPosition: {x: 497, y: -1102}
   m_SizeDelta: {x: 200, y: 60}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &13552251
@@ -404,11 +404,11 @@ RectTransform:
   m_Father: {fileID: 536181274}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.00029659, y: 621.4473}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -11}
   m_SizeDelta: {x: 732.58, y: 347.2379}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!1 &93529738
 GameObject:
   m_ObjectHideFlags: 0
@@ -1405,8 +1405,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.00045776, y: 0.00003889196}
-  m_SizeDelta: {x: 732.58, y: 1630.9}
+  m_AnchoredPosition: {x: 0.00045776, y: 3.7484}
+  m_SizeDelta: {x: 732.58, y: 1412.5532}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &550636393
 GameObject:
@@ -3127,7 +3127,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.14600801, y: 31.5229}
+  m_AnchoredPosition: {x: -0.14600801, y: 9}
   m_SizeDelta: {x: 732.29, y: 145.1843}
   m_Pivot: {x: 0.5, y: 0.5763131}
 --- !u!1 &1062603536
@@ -4850,7 +4850,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -1266.1951}
+  m_AnchoredPosition: {x: 0, y: -1168.1951}
   m_SizeDelta: {x: 696.426, y: 364.705}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1708205104
@@ -6153,8 +6153,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.73800004}
   m_AnchorMax: {x: 0, y: 0.73800004}
-  m_AnchoredPosition: {x: 365.9975, y: -194.01}
-  m_SizeDelta: {x: 732.58, y: 387.98}
+  m_AnchoredPosition: {x: 365.9975, y: -117.26872}
+  m_SizeDelta: {x: 732.58, y: 256.5175}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2031151766
 GameObject:
@@ -6398,7 +6398,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.29184, y: -214.46039}
+  m_AnchoredPosition: {x: -0.29184, y: -242}
   m_SizeDelta: {x: 732.58, y: 248.8428}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2078669445
@@ -6683,8 +6683,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 5.3157, y: 23.443}
-  m_SizeDelta: {x: 732.5817, y: 1635.3}
+  m_AnchoredPosition: {x: -0.0000042915, y: 0.0000076293945}
+  m_SizeDelta: {x: 732.5817, y: 1420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2131212020
 MonoBehaviour:
@@ -6739,9 +6739,9 @@ MonoBehaviour:
   m_Content: {fileID: 536181274}
   m_Horizontal: 0
   m_Vertical: 1
-  m_MovementType: 1
+  m_MovementType: 0
   m_Elasticity: 0.1
-  m_Inertia: 1
+  m_Inertia: 0
   m_DecelerationRate: 0.135
   m_ScrollSensitivity: 1
   m_Viewport: {fileID: 0}


### PR DESCRIPTION
1. iOS: messaging
2. c#: buttons to test messaging. Multiple messages in the log, add timestamp

iOS native contains now 3 header files:
1.`OptimovePluginInterface.h` -- functions usable from c#
2. `Objc-swift-bridging-header.h` -- to call swift methods from objc wrapper
3. `Swift-objc-bridging-header.h` and `UnityFramework.modulemap`. After 2019.2 Unity comes into a native iOS project as a framework. It's not possible to add a bridging header to a framework. To avoid modifying umbrella header, we set a custom modulemap. This modulemap contains objc function declarations enabling us call them from swift.