### PR TITLE
201841: The documentation is moved to dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,41 +7,8 @@ Optimove Unity SDK supports Unity >= 2019.3. Supported platforms are iOS and And
 
 ## Integration Guide
 
-[Developer Docs](https://developer.optimove.com/docs/optimove-sdk-unity)
-
-#### ================= Android =================
-
-1. create a new project
-2. switch platform: Android
-3. set package id (Player Settings -> Other Settings)
-4. import OptimoveSDKUnity package
-5. add OptimoveInit to MainCamera
-6. in Player Settings verify (it should be set automatically):
-    - custom gradle main template set to `Plugins/Android/mainTemplate.gradle`,
-    - custom gradle launcher template set to `Plugins/Android/launcherTemplate.gradle`
-    - custom gradle base template set to `Plugins/Android/baseProjectTemplate.gradle`
-    - custom main manifest set to `Plugins/Android/AndroidManifest.xml`.
-    - for 2020.3+ make sure custom gradle properties template set to `Plugins/Android/gradleTemplate.properties`
-7. If using push/ddl uncomment relevant lines in gradle templates and `AndroidManifest.xml`
-8. Create `Assets/OptimoveConfigFiles/optimove.json`, set credentials
-9. If using push push add `google-services.json` to `Assets/OptimoveConfigFiles/google-services.json`
-10. (Optional) Export project
-
-#### ================= iOS =================
-
-1. create a new project
-2. switch platform to ios
-3. set bundle id (Player Settings -> Other Settings)
-4. import OptimoveSDKUnity package
-5. add OptimoveInit to MainCamera
-6. Create `Assets/OptimoveConfigFiles/optimove.json`, set credentials
-7. Move `Artifacts/OptimoveNativeAssets~` to `Assets` folder
-8. build project. Depending on values in `optimove.json` this automatically adds capabilities, NotificationServiceExtension and sets up Xcode project.
-
-##### In Xcode project
-
-9. signing (if was not set in Unity Player Settings)
-10. Switch to New Build System in File -> Project Settings -> Build System (likely already on). This is necessary to use xcframeworks.
+[Getting Started on Mobile](https://developer.optimove.com/docs/getting-started-on-mobile)
+[SDK Reference](https://developer.optimove.com/docs/sdk-reference-1)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,6 @@ Optimove Unity SDK supports Unity >= 2019.3. Supported platforms are iOS and And
 
 [Developer Docs](https://developer.optimove.com/docs/optimove-sdk-unity)
 
-## Repository structure
-
-This repository contains 3 folders:
-1. `Artifacts` has everything necessary to integrate with Optimove Unity SDK. This includes `Optimove.unitypackage` and `OptimoveNativeAssets~` required if integrating with iOS.
-2. `unity-sdk` contains a Unity project used to create `Optimove.unitypackage`.
-3. `ExampleApp` is an example project with imported `Optimove.unitypackage`. Check `ExampleApp/README.md` if you want to run it.
-
-
 #### ================= Android =================
 
 1. create a new project
@@ -34,7 +26,6 @@ This repository contains 3 folders:
 8. Create `Assets/OptimoveConfigFiles/optimove.json`, set credentials
 9. If using push push add `google-services.json` to `Assets/OptimoveConfigFiles/google-services.json`
 10. (Optional) Export project
-
 
 #### ================= iOS =================
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,21 @@
 # Optimove-SDK-Unity
 ![GitHub](https://img.shields.io/github/license/optimove-tech/Optimove-SDK-Unity?style=flat-square)
 
-# Unity Version And Platform Support
+## Unity Version And Platform Support
 
 Optimove Unity SDK supports Unity >= 2019.3. Supported platforms are iOS and Android.
 
-# Integration Guide
+## Integration Guide
 
-In this guide we will discuss the steps to integrate the Optimove Unity SDK with your application.
+[Developer Docs](https://developer.optimove.com/docs/optimove-sdk-unity)
 
-### Setup
+## Repository structure
 
-1. [Initializing the SDK](https://github.com/optimove-tech/Optimove-SDK-Unity/wiki/Initializing-the-sdk)
-2. [Tracking customers](https://github.com/optimove-tech/Optimove-SDK-Unity/wiki/Tracking-customers)
-3. [Tracking events](https://github.com/optimove-tech/Optimove-SDK-Unity/wiki/Tracking-events)
+This repository contains 3 folders:
+1. `Artifacts` has everything necessary to integrate with Optimove Unity SDK. This includes `Optimove.unitypackage` and `OptimoveNativeAssets~` required if integrating with iOS.
+2. `unity-sdk` contains a Unity project used to create `Optimove.unitypackage`.
+3. `ExampleApp` is an example project with imported `Optimove.unitypackage`. Check `ExampleApp/README.md` if you want to run it.
 
-### Mobile Messaging
-
-1. [Push Setup](https://github.com/optimove-tech/Optimove-SDK-Unity/wiki/push-setup)
-2. [In-App Setup](https://github.com/optimove-tech/Optimove-SDK-Unity/wiki/in-app)
-3. [Deferred Deep Linking](https://github.com/optimove-tech/Optimove-SDK-Unity/wiki/deferred-deep-linking)
-4. [Testing](https://github.com/optimove-tech/Optimove-SDK-Unity/wiki/testing-troubleshooting)
-
-> **NOTE**:
-To unlock these capabilities, you will need to have added the relevant OptiMobile channels to your Optimove package. If you can’t see this feature in your Optimove instance, contact your CSM to find out more.
-
-### Integration summaries
-
-This is a quick start integration guide. For detailed integration instructions refer to the above.
 
 #### ================= Android =================
 


### PR DESCRIPTION
# User description
### Description of Changes

To unify the documentation, the information on Github is moved to the developers docs

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md
- [ ] After update android proxy classes, rebuild `OptimoveUnityPlugin.aar`
- [ ] Make sure changes are present in both `ExampleApp` and `unity-sdk` projects
- [ ] When exporting `.unitypackage` from `unity-sdk` don't include dependencies, don't export scene

Bump versions in:

- [ ] `OptimoveSDKPlugin.swift`
- [ ] `OptimoveInitProvider.java`
- [ ] `Optimove-x.x.x.unitypackage` should have a name matching release version

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Create a tag matching release version
- [ ] Delete branch once merged

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Relocates the detailed integration and setup documentation for the Optimove Unity SDK from the <code>README.md</code> file to the official developer documentation portal. Directs users to external links within <code>README.md</code> for comprehensive guides on getting started and SDK reference.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>kris_e@optimove.com</td><td>Update-README.md</td><td>March 19, 2025</td></tr>
<tr><td>eligutovsky</td><td>docs-add-note-15</td><td>September 26, 2023</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/optimove-tech/Optimove-SDK-Unity/17?tool=ast>(Baz)</a>.